### PR TITLE
Make kanboard an official app

### DIFF
--- a/community.json
+++ b/community.json
@@ -245,12 +245,6 @@
         "state": "inprogress",
         "url": "https://github.com/julienmalik/jitsi_ynh"
     },
-    "kanboard": {
-        "branch": "master",
-        "revision": "161eebeaabf0f09035b7f68146be74eecf2ceeca",
-        "state": " ready",
-        "url": "https://github.com/mbugeia/kanboard_ynh"
-    },
     "kiwiirc": {
         "branch": "master",
         "revision": "c0aba5c4e2232d837299fe0cba12a962dd0f3bfa",

--- a/official.json
+++ b/official.json
@@ -37,7 +37,7 @@
     },
     "kanboard": {
         "branch": "master",
-        "revision": "57b75a631a3dbdb87f13901f5df7ac1ac64f8c54",
+        "revision": "c3c1e73a35c4f8da171370b9cbe6b60af95fed4c",
         "state": " validated",
         "url": "https://github.com/mbugeia/kanboard_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -37,7 +37,7 @@
     },
     "kanboard": {
         "branch": "master",
-        "revision": "f03ca74f245282c8e82c0d51387a8b1bc7ee4a0f",
+        "revision": "57b75a631a3dbdb87f13901f5df7ac1ac64f8c54",
         "state": " validated",
         "url": "https://github.com/mbugeia/kanboard_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -35,6 +35,12 @@
         "state": "validated",
         "url": "https://github.com/julienmalik/jirafeau_ynh"
     },
+    "kanboard": {
+        "branch": "master",
+        "revision": "f03ca74f245282c8e82c0d51387a8b1bc7ee4a0f",
+        "state": " validated",
+        "url": "https://github.com/mbugeia/kanboard_ynh"
+    },
     "my_webapp": {
         "branch": "master",
         "revision": "2899cd7fee00f9dd14bacb3517479db5ce9e627c",


### PR DESCRIPTION
Hi,
I'd like to propose Kanboard as an official Yunohost app.

Pros:
 - There isn't any official app that do project management
 - Kanboard is stable and in active development
 - Good integration with SSOwat
 - Package is easy to maintain/update

Cons:
 - UI is not very sexy
 - A little security bug that I hope will be fixed soon https://github.com/fguillot/kanboard/issues/1391