### PR TITLE
Add .git extension

### DIFF
--- a/community.json
+++ b/community.json
@@ -231,7 +231,7 @@
         "branch": "master",
         "revision": "484eda6f261965a0198f374607716d11463cf3cc",
         "state": "inprogress",
-        "url": "https://moul.re/repo/moul/jappix_mini_ynh/"
+        "url": "https://moul.re/repo/moul/jappix_mini_ynh.git/"
     },
     "jeedom": {
         "branch": "master",


### PR DESCRIPTION
Add .git extension which is needed to build the list for Gogs and GitLab repositories.