### PR TITLE
Update HTPC-Manager

### DIFF
--- a/community.json
+++ b/community.json
@@ -215,11 +215,11 @@
         "state": "working",
         "url": "https://github.com/isserterrus/htmltools_ynh"
     },
-    "htpc": {
+    "htpc-manager": {
         "branch": "master",
-        "revision": "5247c869c55046bfef919940ed965c652904fae8",
-        "state": "working",
-        "url": "https://github.com/lunarok/htpc_ynh"
+        "revision": "8167ef9705e3e063278501f5cc2f6b1169241352",
+        "state": "inprogress",
+        "url": "https://github.com/scith/htpc-manager_ynh"
     },
     "hubzilla": {
         "branch": "master",


### PR DESCRIPTION
The app did not seem to be maintained anymore. I forked and did the following changes:
- Use Hellowlol fork of HTPC-Manager
- Put the YunoHost scripts to standards
- Use systemd instead of init