### PR TITLE
Add Mattermost app

### DIFF
--- a/community.json
+++ b/community.json
@@ -341,6 +341,12 @@
         "state": "inprogress",
         "url": "https://github.com/alexAubin/mailman_ynh"
     },
+    "mattermost": {
+        "branch": "master",
+        "revision": "c91bcb1b75598f9f71a1ea0b156b8d872ab8d890",
+        "state": "working",
+        "url": "https://github.com/kemenaran/mattermost_ynh"
+    },
     "mediagoblin": {
         "branch": "master",
         "revision": "e516845becf6fa640b2dd7de5b9cb36e89be0ae1",


### PR DESCRIPTION
Add Mattermost (an open-source, alternative to Slack). See www.mattermost.com