### PR TITLE
Remove Let's Chat app

### DIFF
--- a/community.json
+++ b/community.json
@@ -299,12 +299,6 @@
         "state": "working",
         "url": "https://github.com/Yunohost-Apps/lektor_ynh"
     },
-    "letschat": {
-        "branch": "master",
-        "revision": "6dab248ab80499cb3a1c8db2dd44db6bd722e64e",
-        "state": "working",
-        "url": "https://github.com/kemenaran/yunohost-lets-chat"
-    },
     "letsencrypt": {
         "branch": "master",
         "revision": "e498e05ebfc52880992507988571d24c35a3cd4c",


### PR DESCRIPTION
I wrote the Let's Chat Yunohost script – but it is officially deprecated (and probably not working).