### PR TITLE
[enh] all apps have been migration to the official app

### DIFF
--- a/official.json
+++ b/official.json
@@ -45,7 +45,7 @@
         "branch": "master",
         "revision": "d769d6292e821e6e8b541b6adf1578b321cebf59",
         "state": "validated",
-        "url": "https://github.com/Kloadut/my_webapp_ynh"
+        "url": "https://github.com/YunoHost-apps/my_webapp_ynh"
     },
     "opensondage": {
         "branch": "master",
@@ -57,13 +57,13 @@
         "branch": "master",
         "revision": "ccb123ec51373b5967079ff868bbe2e0327ee25c",
         "state": "validated",
-        "url": "https://github.com/Kloadut/openvpn_ynh"
+        "url": "https://github.com/YunoHost-apps/openvpn_ynh"
     },
     "owncloud": {
         "branch": "master",
         "revision": "c54cc946a179f36fe946829d7f0b6af1ec095085",
         "state": "validated",
-        "url": "https://github.com/Kloadut/owncloud_ynh"
+        "url": "https://github.com/YunoHost-apps/owncloud_ynh"
     },
     "phpmyadmin": {
         "branch": "master",
@@ -75,13 +75,13 @@
         "branch": "master",
         "revision": "e1935dfc311de2700ea2cb7ad74dcc1519dbae2f",
         "state": "validated",
-        "url": "https://github.com/Kloadut/roundcube_ynh"
+        "url": "https://github.com/YunoHost-apps/roundcube_ynh"
     },
     "searx": {
         "branch": "master",
         "revision": "ac86822c6e7318a5107a029feb37f7cea3b7680f",
         "state": "validated",
-        "url": "https://github.com/abeudin/searx_ynh"
+        "url": "https://github.com/YunoHost-apps/searx_ynh"
     },
     "shellinabox": {
         "branch": "master",
@@ -99,7 +99,7 @@
         "branch": "master",
         "revision": "ff95c44064f7f420d382e2031c3c44d24932108d",
         "state": "validated",
-        "url": "https://github.com/Kloadut/transmission_ynh"
+        "url": "https://github.com/YunoHost-apps/transmission_ynh"
     },
     "ttrss": {
         "branch": "master",
@@ -117,7 +117,7 @@
         "branch": "master",
         "revision": "0f11cab9e065c5e1fd714eb800e35614973a3c7b",
         "state": "validated",
-        "url": "https://github.com/abeudin/wordpress_ynh"
+        "url": "https://github.com/YunoHost-apps/wordpress_ynh"
     },
     "zerobin": {
         "branch": "master",


### PR DESCRIPTION
@opi @jeromelebleu je sais plus si tout est bon pour être indiqué comme étant dans l'orga des apps donc je vous laisse cliquer sur "merge" (même si théoriquement comme les hashs des commits sont les mêmes ça changera rien).