### PR TITLE
Add Nextcloud to the official app list

### DIFF
--- a/official.json
+++ b/official.json
@@ -49,7 +49,7 @@
     },
     "nextcloud": {
         "branch": "master",
-        "revision": "feb5ac0ebc2c1cc85a94ffdee3f2937250481ee1",
+        "revision": "b95586585355df227a44f5176f48f4c434bf84d0",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -47,6 +47,12 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/my_webapp_ynh"
     },
+    "nextcloud": {
+        "branch": "master",
+        "revision": "feb5ac0ebc2c1cc85a94ffdee3f2937250481ee1",
+        "state": "validated",
+        "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
+    },
     "opensondage": {
         "branch": "master",
         "revision": "16153c0acccdb4b708e6cbe4dd5407b1c503e9d1",


### PR DESCRIPTION
As the Nextcloud package for YunoHost is mainly based on ownCloud one, I think it can be considered as _stable_. It has been announced on the forum - see [this article](https://forum.yunohost.org/t/will-there-be-a-nextcloud-app/) - and by the way tested several times.

Regarding the ownCloud to Nextcloud migration - as described [here](https://github.com/YunoHost-Apps/nextcloud_ynh#migrate-from-owncloud), I think it needs more tests. That's why I let the warning notice. However, we should not wait more to integrate this app in the official list, for all the new installations...
