### PR TITLE
Make gogs an official yunohost app

### DIFF
--- a/community.json
+++ b/community.json
@@ -247,7 +247,7 @@
     },
     "gogs": {
         "branch": "master",
-        "revision": "0d23145c917ff168743c2ec071d865400350c076",
+        "revision": "46fb1398c7bad7718988c98572111c5fd25cbc9f",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/gogs_ynh"
     },

--- a/community.json
+++ b/community.json
@@ -245,12 +245,6 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/gnusocial_ynh"
     },
-    "gogs": {
-        "branch": "master",
-        "revision": "46fb1398c7bad7718988c98572111c5fd25cbc9f",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/gogs_ynh"
-    },
     "hotspot": {
         "branch": "master",
         "revision": "850f19584efe0764642587bb49ba47e73415be6b",

--- a/official.json
+++ b/official.json
@@ -109,7 +109,7 @@
     },
     "wordpress": {
         "branch": "master",
-        "revision": "fe06981818b36b98256f56712da06bde301b73ce",
+        "revision": "034fcde60d7b512c0ded33f75e41a798b931100a",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wordpress_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -17,6 +17,12 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },
+    "gogs": {
+        "branch": "master",
+        "revision": "46fb1398c7bad7718988c98572111c5fd25cbc9f",
+        "state": "validated",
+        "url": "https://github.com/YunoHost-Apps/gogs_ynh"
+    },
     "hextris": {
         "branch": "master",
         "revision": "88d1916eceb760d62a9a3ea7bc5c4c6240a5840e",


### PR DESCRIPTION
I'd love to make gogs an official yunohost app. I've updated the package to fix all the opened issues and to use new yunohost helpers.

Everything works well on my yunohost (including backup/restore) but the package need some external testing (and on other hardware, I only have x64 hardware).

Please let me know the result of your test and if some thing have to be improved :smiley:
