### PR TITLE
[mod] ffsync: set app notworking and update hash.

### DIFF
--- a/community.json
+++ b/community.json
@@ -169,8 +169,8 @@
     },
     "ffsync": {
         "branch": "master",
-        "revision": "6eed9ad333d7411bf59b63f09562bc6513500507",
-        "state": "working",
+        "revision": "6707f664bbb39e18dd1ab6801d4c4524294e6c91",
+        "state": "inprogress",
         "url": "https://github.com/abeudin/ffsync_ynh"
     },
     "filebin": {


### PR DESCRIPTION
I consider this is a minor vote, following rules needs to be completed before closing this PR:
- needs three votes. Two others. As mine is given doing this pull request.
- 66% of positives votes.
- vote will ends in one week: 4th November 2016.
- If you consider one this rules is wrong, please ask for modification.

Reasons:
- ffsync did not have commits since 6 months ago.
- It's not enough documented to make it works.
- [Many major install and sync bugs tickets](https://github.com/abeudin/ffsync_ynh/issues)
- Many user can't make it works (including myself).
- [Recent user can't make it works on the forum](https://forum.yunohost.org/t/firefox-sync-comment-que-cela-marche/2047)

If it works fine on your side, we could put it to `inprogress` status.

I ping contributors which could have make it works.
@abeudin, @julienmalik, @Josue-T, @lmangani, @matlink
