### PR TITLE
Make Keeweb an official app?

### DIFF
--- a/community.json
+++ b/community.json
@@ -317,12 +317,6 @@
         "state": "inprogress",
         "url": "https://github.com/julienmalik/jitsi_ynh"
     },
-    "keeweb": {
-        "branch": "master",
-        "revision": "7d9b511bd7f400f261c247ba943a270f8c2f7bb0",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/keeweb_ynh"
-    },
     "kiwiirc": {
         "branch": "master",
         "revision": "c0aba5c4e2232d837299fe0cba12a962dd0f3bfa",

--- a/official.json
+++ b/official.json
@@ -41,6 +41,12 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/kanboard_ynh"
     },
+    "keeweb": {
+        "branch": "master",
+        "revision": "9e5c65c461a22d9b85be732e072ff938911106ad",
+        "state": "validated",
+        "url": "https://github.com/YunoHost-Apps/keeweb_ynh"
+    },
     "my_webapp": {
         "branch": "master",
         "revision": "c52418b955cacc0365cc10e8cf4700ddb9723d38",


### PR DESCRIPTION
See https://github.com/YunoHost-Apps/keeweb_ynh/issues/1 for YEPs status
I need more people to test
Plus this concern I have about how to deal with browser local storage when users log out of YunoHost?

- [x] YEP 1.8: To do
- [x] YEP 1.10: Sources are synced with upstream
- [ ] YEP 1.11: To do
- [ ] **YEP 2.10**: To do, but how??
- [ ] **YEP 2.18.5**: Not working, why not?
- [ ] YEP 3.4: Is it needed for this app?
- [ ] YEP 3.6: What is this?
- [ ] YEP 4.1: No user management in Keeweb. Is it needed to develop a custom link (with confs for each user), given that users can store the conf in the web browser?
- [ ] YEP 4.2: Same
- [ ] **YEP 4.2.1**: Not sure when the conf is destroyed, as it lives in the user's browser storage...

Up for debate :)
Thanks