### PR TITLE
Removal of opendkim_ynh

### DIFF
--- a/community.json
+++ b/community.json
@@ -479,12 +479,6 @@
         "state": "inprogress",
         "url": "https://github.com/nomakaFr/ofbiz_ynh"
     },
-    "opendkim": {
-        "branch": "master",
-        "revision": "35272eee601aa072efc55ea4db5d356205a668d6",
-        "state": "inprogress",
-        "url": "https://github.com/polytan02/opendkim_ynh"
-    },
     "openidsimplesamlphp": {
         "branch": "master",
         "revision": "f992c392a31e37421b339b8a6cfb736e0d5097a8",


### PR DESCRIPTION
Not required anymore since it is integrated natively within latest stable release of Yunohost.
Thank you for having integrated it ! :)