### PR TITLE
New cops_ynh

### DIFF
--- a/community.json
+++ b/community.json
@@ -87,11 +87,11 @@
         "branch": "master",
         "revision": "b7ecfa3f48d83fc0af0f249498a20d958bdb6f02",
         "state": "working",
-        "url": "https://github.com/lunarok/cops_ynh"
+        "url": "https://github.com/YunoHost-Apps/cops_ynh"
     },
     "couchpotato": {
         "branch": "master",
-        "revision": "89813896d3692857a20f421d001c37c5c7c5ddd6",
+        "revision": "8e0d9482907d3303087c1936944ec636f0162126",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/couchpotato_ynh"
     },


### PR DESCRIPTION
compatible with yunohost 2.4
Upgrade and restore
OK with package_linter
Should be ok with package_check