### PR TITLE
New cops_ynh

### DIFF
--- a/community.json
+++ b/community.json
@@ -85,9 +85,9 @@
     },
     "cops": {
         "branch": "master",
-        "revision": "b7ecfa3f48d83fc0af0f249498a20d958bdb6f02",
+        "revision": "8e0d9482907d3303087c1936944ec636f0162126",
         "state": "working",
-        "url": "https://github.com/lunarok/cops_ynh"
+        "url": "https://github.com/YunoHost-Apps/cops_ynh"
     },
     "couchpotato": {
         "branch": "master",


### PR DESCRIPTION
Compatible with yunohost 2.4
Use latest sources 1.0.1
Upgrade and Restore ok
OK with package_linter
To be validated by Jenkins and Package_check