### PR TITLE
Transfer to the community repository

### DIFF
--- a/community.json
+++ b/community.json
@@ -188,8 +188,8 @@
     "framagames": {
         "branch": "master",
         "revision": "be7fc1e39498fac6706f15fe55f3852c8b965363",
-        "state": "working",
-        "url": "https://github.com/polytan02/framagames_ynh"
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/framagames_ynh"
     },
     "freeboard.io": {
         "branch": "master",


### PR DESCRIPTION
Transfer of framagames_ynh to the community repository
Needs updating to be fully compliant with yunohost 2.4