### PR TITLE
Mattermost et friendica cassés

### DIFF
--- a/community.json
+++ b/community.json
@@ -206,7 +206,7 @@
     "friendica": {
         "branch": "master",
         "revision": "8ee66ae8bf3c5a581fd6e7e59a36ca0d914a9378",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/aymhce/friendica_ynh"
     },
     "ftp_webapp": {
@@ -386,7 +386,7 @@
     "mattermost": {
         "branch": "master",
         "revision": "c91bcb1b75598f9f71a1ea0b156b8d872ab8d890",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/kemenaran/mattermost_ynh"
     },
     "mediagoblin": {


### PR DESCRIPTION
Premières victimes de l'intégration continue, mattermost et friendica échouent à l'installation.
Ces apps devraient donc ne plus être considérée comme fonctionnelles.

[Décision mineure](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure), clôture au 02 janvier.