### PR TITLE
Etherpadlite, gateone et glpi cassés

### DIFF
--- a/community.json
+++ b/community.json
@@ -164,7 +164,7 @@
     "etherpadlite": {
         "branch": "master",
         "revision": "3dfaa71dbadf7befa110e685935cd2350e988bb1",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/abeudin/etherpadlite_ynh"
     },
     "ffsync": {
@@ -218,7 +218,7 @@
     "gateone": {
         "branch": "master",
         "revision": "c89df3696e42dab8dff512dcc57eff786c5ff48c",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/Kloadut/gateone_ynh"
     },
     "ghostblog": {
@@ -242,7 +242,7 @@
     "glpi": {
         "branch": "master",
         "revision": "5982ac51159d42cef1c969b479346d6bc95abba5",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/abeudin/glpi_ynh"
     },
     "gnusocial": {


### PR DESCRIPTION
Nouvelles victimes de l'intégration continue, etherpadlite, gateone et glpi échouent à l'installation.
Ces apps devraient donc ne plus être considérée comme fonctionnelles.

[Décision mineure](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure), clôture au 06 janvier.