### PR TITLE
Mark Mattermost as fixed

### DIFF
--- a/community.json
+++ b/community.json
@@ -391,8 +391,8 @@
     },
     "mattermost": {
         "branch": "master",
-        "revision": "c91bcb1b75598f9f71a1ea0b156b8d872ab8d890",
-        "state": "notworking",
+        "revision": "4b2890ba1dbd5c3070477b30ec2525399b0c7b96",
+        "state": "working",
         "url": "https://github.com/kemenaran/mattermost_ynh"
     },
     "mediagoblin": {


### PR DESCRIPTION
Following #110 and https://github.com/kemenaran/mattermost_ynh/issues/10, I fixed the installation of Mattermost on a fresh Yunohost 2.4 / Debian 8 setup.