### PR TITLE
Owncloud community

### DIFF
--- a/community.json
+++ b/community.json
@@ -546,6 +546,13 @@
         "state": "working",
         "url": "https://github.com/lunarok/openwrt_ynh"
     },
+    "owncloud": {
+        "branch": "master",
+        "revision": "2de9a45ea28b7f713872715b9dd284c0fe71beb8",
+        "state": "validated",
+        "level": 4,
+        "url": "https://github.com/YunoHost-apps/owncloud_ynh"
+    },
     "phpBB": {
         "branch": "master",
         "revision": "75bc49dcc34c3e84b9424b262d8d3fbda491e110",

--- a/official.json
+++ b/official.json
@@ -68,13 +68,6 @@
         "level": 2,
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
-    "owncloud": {
-        "branch": "master",
-        "revision": "2de9a45ea28b7f713872715b9dd284c0fe71beb8",
-        "state": "validated",
-        "level": 4,
-        "url": "https://github.com/YunoHost-apps/owncloud_ynh"
-    },
     "phpmyadmin": {
         "branch": "master",
         "revision": "044485c1fcd16409c5a7bacbea924621cc612ac8",


### PR DESCRIPTION
Proposition de retirer owncloud de la liste officielle et de le passer en communautaire pour le moment.
Remplacé par Nextcloud.