### PR TITLE
Update of z-push_ynh to follow YEP 3.3

### DIFF
--- a/community.json
+++ b/community.json
@@ -808,7 +808,7 @@
     "z-push": {
         "branch": "master",
         "level": 7,
-        "revision": "3df65e033be4d05f0ff24e3126756e0d04dc5b6f",
+        "revision": "590a16ee8d2759ca072efaee11aa2f8f227aee1f",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/z-push_ynh"
     },


### PR DESCRIPTION
Update of z-push_ynh to follow YEP 3.3 : We download sources and check md5 instead of storing the sources in the app depot.