### PR TITLE
Update wordpress

### DIFF
--- a/official.json
+++ b/official.json
@@ -135,7 +135,7 @@
     "wordpress": {
         "branch": "master",
         "level": 7,
-        "revision": "488dc5bd7855f940857ff55d4063a531ba503c0f",
+        "revision": "e73a7ee0636ec1e3b493fd477e7fe2c9b7860e03",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wordpress_ynh"
     },


### PR DESCRIPTION
- Mise à jour de wordpress en version 4.7.2
- Correction sur l'appel curl
- Téléchargement de wp-cli.phar plutôt que d'utiliser une version embarquée.

[Décision mineure](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Clôture au 20 février, ou 16 si anticipé.