### PR TITLE
Adds zeronet_ynh to community.json

### DIFF
--- a/community.json
+++ b/community.json
@@ -880,6 +880,13 @@
         "state": "working",
         "url": "https://github.com/chtixof/yunofav"
     },
+    "zeronet": {
+        "branch": "master",
+        "level": 3,
+        "revision": "a74d3f7ddb264c10f0c35185b46aefac99d7b59a",
+        "state": "working",
+        "url": "https://github.com/whypsi/zeronet_ynh"
+    },
     "z-push": {
         "branch": "master",
         "level": 7,

--- a/community.json
+++ b/community.json
@@ -882,10 +882,9 @@
     },
     "zeronet": {
         "branch": "master",
-        "level": 3,
         "revision": "a74d3f7ddb264c10f0c35185b46aefac99d7b59a",
         "state": "working",
-        "url": "https://github.com/whypsi/zeronet_ynh"
+        "url": "https://github.com/YunoHost-Apps/zeronet_ynh"
     },
     "z-push": {
         "branch": "master",


### PR DESCRIPTION
Hello YunoHosters, 

this pull request shall bring ZeroNet to the YunoHost community. ZeroNet provides _Decentralized websites using Bitcoin crypto and the BitTorrent network_ as the author coins it.

The app cannot be installed on path, must be installed on a sub-domain.

I've tested install, remove, upgrade, backup and restore manually and it works.

"package_check" script succeeds as well except for multi-instance test which had to be disabled because it uses installation on path which is not compatible. I've tested multi-instance manually and it works.

A thorough testing of the ZeroNet on a SOC device (like InternetCube with Olimex LIME 2) still needs to be done.

I have given the app a quality level of 3.

Looking forward to your feedback.

With kind regards,

whypsi