### PR TITLE
Update community.json

### DIFF
--- a/community.json
+++ b/community.json
@@ -192,10 +192,10 @@
         "url": "https://github.com/abeudin/etherpadlite_ynh"
     },
     "ffsync": {
-        "branch": "master",
-        "revision": "6707f664bbb39e18dd1ab6801d4c4524294e6c91",
-        "state": "inprogress",
-        "url": "https://github.com/abeudin/ffsync_ynh"
+        "branch": "yunohost-app",
+        "revision": "5638dd2da3c6f49b9ae59cb523f1633e438e10b7",
+        "state": "working",
+        "url": "https://github.com/rigelk/ffsync_ynh"
     },
     "filebin": {
         "branch": "master",


### PR DESCRIPTION
- Replace Firefox Sync (ffsync_ynh) with an updated version (and also replace abeudin's apparently unmaintained repo).

See [discussion about my PR](https://github.com/abeudin/ffsync_ynh/pull/22#issuecomment-281053261) on abeudin's repo for more information about the proposed change of repository.