### PR TITLE
Update Nextcloud to 11.0.2 (official)

### DIFF
--- a/official.json
+++ b/official.json
@@ -58,7 +58,7 @@
     "nextcloud": {
         "branch": "master",
         "level": 7,
-        "revision": "524deb037fe51b7453d3eaf077da996bfb359d70",
+        "revision": "beb6dc9d9033d0badb15c05669bc0987f840b148",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
     },


### PR DESCRIPTION
* Mise à jour mineure de la version Nextcloud (de 11.0.1 à 11.0.2).
* Pas de modification de fond sur le package.

[Décision mineure](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Clôture au 12 mars, ou 8 mars si anticipé.