### PR TITLE
Update community.json

### DIFF
--- a/community.json
+++ b/community.json
@@ -193,9 +193,9 @@
     },
     "ffsync": {
         "branch": "yunohost-app",
-        "revision": "5638dd2da3c6f49b9ae59cb523f1633e438e10b7",
+        "revision": "fd6350495d5a1d864ae30e1a61e18939fdb6a428",
         "state": "working",
-        "url": "https://github.com/rigelk/ffsync_ynh"
+        "url": "https://github.com/YunoHost-Apps/ffsync_ynh"
     },
     "filebin": {
         "branch": "master",


### PR DESCRIPTION
- Replaces Firefox Sync (ffsync_ynh) with the now transfered repo to YunoHost-Apps.

Since I transfered ownership to YunoHost-Apps, the remote had to be changed as well here after #169 and [this bug](https://github.com/abeudin/ffsync_ynh/issues/23).