### PR TITLE
Update Kanboard to 1.0.40

### DIFF
--- a/official.json
+++ b/official.json
@@ -44,7 +44,7 @@
     "kanboard": {
         "branch": "master",
         "level": 4,
-        "revision": "5c112f0f221109e5760f9f3828eaae75df4e8f9b",
+        "revision": "096e55b26b43d8d66536e41c85a299d9b6bd1288",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/kanboard_ynh"
     },


### PR DESCRIPTION
* Minor upgrade to Kanboard version
* No package modification otherwise

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Will be closed on March 18th, or March 14th if decision anticipated.

**Note** : This package is not perfect as-is (e.g. package_check results), but I propose that we don't work on that yet (if the application works, of course!), until we get over our current thinking on helpers and package scripts layout.
Thus we get updates flowing, and we maintain security level.