### PR TITLE
Update Tiny Tiny RSS to 17.1

### DIFF
--- a/official.json
+++ b/official.json
@@ -121,7 +121,7 @@
     "ttrss": {
         "branch": "master",
         "level": 1,
-        "revision": "4d8516d282131ab7499d046fae82e266850988f2",
+        "revision": "6a8fb9f2778046755a6b743f8a45c81248c74b41",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/ttrss_ynh"
     },


### PR DESCRIPTION
* Major upgrade of Tiny Tiny RSS version
* Package updated to download sources at install
* No other modification

[Standard decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-standardmoyenne)
Will be closed on March 25th, or March 18th if decision anticipated.

**Note** : This package is not perfect as-is (e.g. package_check results), but I propose that we don't work on that yet (if the application works, of course!), until we get over our current thinking on helpers and package scripts layout.
Thus we get updates flowing, and we maintain security level.