### PR TITLE
Update official apps to catch up with "doc" commits

### DIFF
--- a/official.json
+++ b/official.json
@@ -23,7 +23,7 @@
     "hextris": {
         "branch": "master",
         "level": 3,
-        "revision": "88d1916eceb760d62a9a3ea7bc5c4c6240a5840e",
+        "revision": "5429ef6d153986c19763f58dc8a093a15b2c7707",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/hextris_ynh"
     },
@@ -65,7 +65,7 @@
     "opensondage": {
         "branch": "master",
         "level": 2,
-        "revision": "16153c0acccdb4b708e6cbe4dd5407b1c503e9d1",
+        "revision": "a1e36e21aaf08c2e3dc53fe1e0121caf2ff34483",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
@@ -100,14 +100,14 @@
     "shellinabox": {
         "branch": "master",
         "level": 3,
-        "revision": "36d5a3905a6ceb791f19a8e6b1f645b8c85c8128",
+        "revision": "43b1ab0ce6383c4de6e4b9fd232dacb8b5e7caa5",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/shellinabox_ynh"
     },
     "strut": {
         "branch": "master",
         "level": 3,
-        "revision": "f4ba74d60e863d2a02a5557493ea932b8fe31e8a",
+        "revision": "ebd1e859cb1ecc0cc3166969fc1db649f3ddb61c",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/strut_ynh"
     },
@@ -128,14 +128,14 @@
     "wallabag": {
         "branch": "master",
         "level": 1,
-        "revision": "81be93aa43a3fec9d1d2e007d9491d2f519160ad",
+        "revision": "eefbdc5231ae7baf93db96b1f57cd4d536735c33",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wallabag_ynh"
     },
     "wordpress": {
         "branch": "master",
         "level": 7,
-        "revision": "e73a7ee0636ec1e3b493fd477e7fe2c9b7860e03",
+        "revision": "6650983a6272dedd357ea2900401ba3bf5c668ce",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wordpress_ynh"
     },


### PR DESCRIPTION
[YunoDash](https://dash.yunohost.org/index.php) is currently impossible to use (almost every application is red) due to many "organizational" commits (check_process, issues location, etc.).
In order to make things cleaner, this commit updates published revision to last updated revision for applications for which the newer commits don't include any software change.

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Will be closed on March 18th, or March 14th if decision anticipated.