### PR TITLE
Update Jirafeau package to solve issue #27 (timeout on huge files)

### DIFF
--- a/official.json
+++ b/official.json
@@ -37,7 +37,7 @@
     "jirafeau": {
         "branch": "master",
         "level": 3,
-        "revision": "dbd28feceef2dc24e96651cb369bf863e5036116",
+        "revision": "f3cacf050c58804e5071dae314c38f3950ebf9d3",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/jirafeau_ynh"
     },


### PR DESCRIPTION
Minor update to Jirafeau package: issue [#27](https://github.com/YunoHost-Apps/jirafeau_ynh/issues/27) (timeout on huge files) solved by PR [#29](https://github.com/YunoHost-Apps/jirafeau_ynh/pull/29).

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Will be closed on March 26th, or March 22nd if decision anticipated.

**Note** : This package is not perfect as-is (e.g. package_check results), but I propose that we don't work on that yet (if the application works, of course!), until we get over our current thinking on helpers and package scripts layout.
Thus we get updates flowing, and we maintain security level.