### PR TITLE
Update Kanboard to 1.0.41

### DIFF
--- a/official.json
+++ b/official.json
@@ -44,7 +44,7 @@
     "kanboard": {
         "branch": "master",
         "level": 4,
-        "revision": "096e55b26b43d8d66536e41c85a299d9b6bd1288",
+        "revision": "8c0c21b9b9d9da926511da6d59e3ae4ea4b9bf6c",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/kanboard_ynh"
     },


### PR DESCRIPTION
Update Kanboard to 1.0.41 and execute database migration during installation (see commit [here](https://github.com/YunoHost-Apps/kanboard_ynh/commit/8c0c21b9b9d9da926511da6d59e3ae4ea4b9bf6c)).

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-mineure)
Will be closed on April 8th, or Aprils 4th if decision anticipated.

**Note** : This package is not perfect as-is (e.g. package_check results), but I propose that we don't work on that yet (if the application works, of course!), until we get over our current thinking on helpers and package scripts layout.
Thus we get updates flowing, and we maintain security level.