### PR TITLE
DokuWiki : Refactoring and upgrade to latest version

### DIFF
--- a/official.json
+++ b/official.json
@@ -16,7 +16,7 @@
     "dokuwiki": {
         "branch": "master",
         "level": 4,
-        "revision": "95b5d8a1baeff004679da17d3ac0063c28759a0a",
+        "revision": "881adf9457d80d1610d496e4fba144eb2ad16472",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -16,7 +16,7 @@
     "dokuwiki": {
         "branch": "master",
         "level": 4,
-        "revision": "d037776267bd3ba7311ca4bb64464516a382a098",
+        "revision": "95b5d8a1baeff004679da17d3ac0063c28759a0a",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -16,7 +16,7 @@
     "dokuwiki": {
         "branch": "master",
         "level": 5,
-        "revision": "795059f3831bdce04be5f15ad922ff847d7cfa67",
+        "revision": "839187ee64a3202f2eb770cd0d5a2ca4153b2735",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -16,7 +16,7 @@
     "dokuwiki": {
         "branch": "master",
         "level": 4,
-        "revision": "881adf9457d80d1610d496e4fba144eb2ad16472",
+        "revision": "795059f3831bdce04be5f15ad922ff847d7cfa67",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },


### PR DESCRIPTION
Following [this PR](https://github.com/YunoHost-Apps/dokuwiki_ynh/pull/23) by @magikcypress (thanks!):
* Major upgrade of DokuWiki version
* Package refactored to adjust to latest standards
* Level 7 in package_check

EDIT : Adding this [small PR](https://github.com/YunoHost-Apps/dokuwiki_ynh/pull/24) to the decision.

[Standard decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#d%C3%A9cision-standardmoyenne)
Will be closed on April 29th, or April 22th if decision anticipated.