### PR TITLE
Update ZeroBin to PrivateBin 1.1

### DIFF
--- a/official.json
+++ b/official.json
@@ -142,7 +142,7 @@
     "zerobin": {
         "branch": "master",
         "level": 3,
-        "revision": "c0cebb4dec7029e51e6a2069f72253af62d72069",
+        "revision": "da0ede6bc810433382334af4f6d697ec6077e3c8",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/zerobin_ynh"
     }

--- a/official.json
+++ b/official.json
@@ -142,7 +142,7 @@
     "zerobin": {
         "branch": "master",
         "level": 3,
-        "revision": "73c9a63333a42a92de6026435368ae3c12610eae",
+        "revision": "c0cebb4dec7029e51e6a2069f72253af62d72069",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/zerobin_ynh"
     }


### PR DESCRIPTION
## Problem

## Solution
- Following [this PR](https://github.com/YunoHost-Apps/zerobin_ynh/pull/15) by @magikcypress (thanks again!):
- Major upgrade of ZeroBin version (now PrivateBin)
- Package refactored to adjust to latest standards
- Level 7 in package_check

This package should be renamed to privatebin, but does YunoHost allow this seamlessly for current zerobin users?

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Medium decision*
- [x] **Complete test** : frju365
- [x] **Upgrade previous version** : Maniack C
- [x] **Code review** : JimboJoe
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- [x] **CI succeeded** : Maniack C -> [Official CI](https://ci-apps.yunohost.org/jenkins/job/zerobin%20(Official)/15/console)
- [x] ~**CI succeeded** :~
One public package check log is enough instead of two checks.  
When the PR is mark as ready to merge, you have to wait for 7 days before really merge it.
