### PR TITLE
Fix TTRSS

### DIFF
--- a/official.json
+++ b/official.json
@@ -121,7 +121,7 @@
     "ttrss": {
         "branch": "master",
         "level": 1,
-        "revision": "b1334ea409c60600a222cd3b4890ba28121c4e3e",
+        "revision": "7bf8c14ec07dff5440baf750a6639ebde21ad24b",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/ttrss_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -121,7 +121,7 @@
     "ttrss": {
         "branch": "master",
         "level": 1,
-        "revision": "6a8fb9f2778046755a6b743f8a45c81248c74b41",
+        "revision": "b1334ea409c60600a222cd3b4890ba28121c4e3e",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/ttrss_ynh"
     },


### PR DESCRIPTION
Hello, the folder within the zip does not match the pattern anymore. As a result, the app won't install anymore...
Here is the fix.

Hello,
I have a strange error:

```
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1183) [sender=3.1.1]
rsync: change_dir "/tmp/tmp.n4cxYSWbPh/tt-rss.git" failed: No such file or directory (2)
+ sudo rsync -a '/tmp/tmp.n4cxYSWbPh/tt-rss.git/*' /var/www/ttrss
+ unzip -q /tmp/ttrss.zip -d /tmp/tmp.n4cxYSWbPh
+ wget -q -O /tmp/ttrss.zip 'https://tt-rss.org/gitlab/fox/tt-rss/repository/archive.zip?ref=17.1'
```