### PR TITLE
Update CouchPotato and SickRage

### DIFF
--- a/community.json
+++ b/community.json
@@ -120,7 +120,7 @@
     "couchpotato": {
         "branch": "master",
         "level": 0,
-        "revision": "5a519665a8339d013259e76d8996f738aa81fee7",
+        "revision": "2fbe760a038a1e65f574d30ffb293c7499229235",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/couchpotato_ynh"
     },
@@ -847,7 +847,7 @@
     "sickrage": {
         "branch": "master",
         "level": 0,
-        "revision": "642d82a84fafc5cfcaac26731ce2a25ffede5285",
+        "revision": "b3a136938ad02d98051fe2cda40a9a2a3d10c763",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/sickrage_ynh"
     },


### PR DESCRIPTION
- Open the /api path so that mobile apps can connect using the API key
- Fix restore