### PR TITLE
Deprecate Jappix app

### DIFF
--- a/community.json
+++ b/community.json
@@ -383,6 +383,12 @@
         "state": "working",
         "url": "https://github.com/JocelynDelalande/ihatemoney_ynh"
     },
+    "jappix": {
+        "branch": "master",
+        "revision": "611170f1575603e65225b4b353f61884c7b0b42e",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/jappix_ynh"
+    },
     "jappix_mini": {
         "branch": "master",
         "revision": "230e99a3a35e165e095ea944acaa7bc5d34acb7c",

--- a/official.json
+++ b/official.json
@@ -27,13 +27,6 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/hextris_ynh"
     },
-    "jappix": {
-        "branch": "master",
-        "level": 7,
-        "revision": "611170f1575603e65225b4b353f61884c7b0b42e",
-        "state": "validated",
-        "url": "https://github.com/YunoHost-Apps/jappix_ynh"
-    },
     "jirafeau": {
         "branch": "master",
         "level": 3,


### PR DESCRIPTION
Jappix is no more maintained since a while.
Moved to community list.
There will be no more web XMPP client on official list.
This must encourage us to push Movim app to official list.