### PR TITLE
Set Wallabag2 as official app instead of Wallabag

### DIFF
--- a/official.json
+++ b/official.json
@@ -120,7 +120,7 @@
     },
     "wallabag2": {
         "branch": "master",
-        "revision": "05b42a4b5e58f758851f44f7e0a2171fde2a62f7",
+        "revision": "5b75043361e511d1ec12dba24f5160d716df57d1",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -118,12 +118,11 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/ttrss_ynh"
     },
-    "wallabag": {
+    "wallabag2": {
         "branch": "master",
-        "level": 1,
-        "revision": "eefbdc5231ae7baf93db96b1f57cd4d536735c33",
+        "revision": "05b42a4b5e58f758851f44f7e0a2171fde2a62f7",
         "state": "validated",
-        "url": "https://github.com/YunoHost-Apps/wallabag_ynh"
+        "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
     },
     "wordpress": {
         "branch": "master",

--- a/official.json
+++ b/official.json
@@ -120,7 +120,7 @@
     },
     "wallabag2": {
         "branch": "master",
-        "revision": "5b75043361e511d1ec12dba24f5160d716df57d1",
+        "revision": "86b31c58d99536ec6eb4cd8d770f24a3eff807eb",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
     },


### PR DESCRIPTION
Work on wallabag2 package is (hopefully) coming to an end!
https://github.com/YunoHost-Apps/wallabag2_ynh

Official maintainer: @lapineige

- The package gets a [level 7](https://jenkins-apps.nohost.me/jenkins/job/wallabag2_ynh/1/) result on package check.

- The package uses new current and forthcomng helpers wherever possible.

There's no automatic upgrade possible from Wallabag 1 to Wallabag 2 (see [official documentation](https://doc.wallabag.org/fr/user/import/wallabagv1.html)).

Wallabag v1 package is now very obsolete, and can't be installed on the domain root (example yesterday [on the forum](https://forum.yunohost.org/t/wallabag-error-403/2932/14)).

[Standard decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization.md#standard-decision)
Will be closed on July 2nd, anytime before if anticipated.

EDIT : Review comments until 25/06/2017 have been taken into account in master branch. Decision postponed until July 2nd.