### PR TITLE
Update ihatemoney version and level

### DIFF
--- a/community.json
+++ b/community.json
@@ -384,8 +384,8 @@
     },
     "ihatemoney": {
         "branch": "master",
-        "level": 1,
-        "revision": "309e46013fdf6909f741dc78845ae6115d1f2071",
+        "level": 7,
+        "revision": "633ea905044780346944a9c17431e4b7575b9e77",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/ihatemoney_ynh"
     },


### PR DESCRIPTION
For the level, I think it meets the requirements for llvl 7 **except for multi-instance installation** (that I didn't implemented, it has little interest IMHO, as ihatemoney is though as a public service). 

But I'd like your opinion on that ? should I put lvl 7 or 2 till multi-instance is supported ?