### PR TITLE
[URGENT] Fix Nextcloud 11.0.3

### DIFF
--- a/official.json
+++ b/official.json
@@ -51,7 +51,7 @@
     "nextcloud": {
         "branch": "master",
         "level": 7,
-        "revision": "8db5554877a4cd77cc5b0f229f07b9186d1baa35",
+        "revision": "2ab89810c66a7914735be96cd4bbe53cd66a2f67",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
     },


### PR DESCRIPTION
I propose to manage this PR as micro-decision as the package is currently totally broken.

Change :  [this fix](https://github.com/YunoHost-Apps/nextcloud_ynh/commit/2ab89810c66a7914735be96cd4bbe53cd66a2f67) (applies this [fix](https://github.com/YunoHost-Apps/nextcloud_ynh/commit/2ab89810c66a7914735be96cd4bbe53cd66a2f67) that's been tested on pending Nextcloud 12 update)

Note: The root cause of that problem is that the 11.0.3 PR was initiated on  YunoHost 2.5, extensive testing were carried on that version, and the last approvals happened with LGTM... but on YunoHost 2.6. Maybe a rule to define to enforce testing happened on the current version when merging?