### PR TITLE
Update Nextcloud, OpenSondage and phpMyAdmin

### DIFF
--- a/official.json
+++ b/official.json
@@ -51,21 +51,21 @@
     "nextcloud": {
         "branch": "master",
         "level": 5,
-        "revision": "2ab89810c66a7914735be96cd4bbe53cd66a2f67",
+        "revision": "cb3ce17086da425f93fd7f65ffb3ea9bdbdf35ef",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
     },
     "opensondage": {
         "branch": "master",
         "level": 2,
-        "revision": "a1e36e21aaf08c2e3dc53fe1e0121caf2ff34483",
+        "revision": "eb508660841801995fe2c66e5bf3259cdbea5922",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
     "phpmyadmin": {
         "branch": "master",
         "level": 2,
-        "revision": "91c90dd9552f27fa2c5ba2464e089b60a29398ba",
+        "revision": "4b36d8df2a4801fea6bc0e6b56c42ff0e5f8f470",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/phpmyadmin_ynh"
     },


### PR DESCRIPTION
Following these validated PRs:
- Nextcloud: [Update to nextcloud 12](https://github.com/YunoHost-Apps/nextcloud_ynh/pull/37)
- OpenSondage: [Remove Framasoft signature](https://github.com/YunoHost-Apps/opensondage_ynh/pull/20)
- phpMyAdmin; [Upgrade upstream version to 4.7.3](https://github.com/YunoHost-Apps/phpmyadmin_ynh/pull/61)

Can be merged directly, as the decision process has been applied for all 3 PRs.
Making a PR for a last cross-check...