### PR TITLE
Upgrade Jeedom

### DIFF
--- a/community.json
+++ b/community.json
@@ -439,7 +439,7 @@
     "jeedom": {
         "branch": "master",
         "level": 0,
-        "revision": "bd0e6b313056026a100d585df3aa4a30fdb8a25f",
+        "revision": "d23e0b30b630740ec66fa83c6505c5afb51698e1",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/jeedom_ynh"
     },


### PR DESCRIPTION
- Use the new example_ynh
- Dedicated Jeedom user instead of www-data (better for sudo if needed)
- No more ZWave dependencies for now

I had to recreate the repository in order to unlink it to the initial, very old repo from Lunarok.

The upgrade seems to work from the old version, but I am not certain because many things have been changed