### PR TITLE
Update hotspot_ynh and vpnclient apps

### DIFF
--- a/community.json
+++ b/community.json
@@ -882,7 +882,7 @@
     "piratebox": {
         "branch": "master",
         "level": 2,
-        "revision": "61bd608b9df1b744f52cde2a3be5540c1d828b35",
+        "revision": "19029e995498660035302adf0ce337cc5296bd7b",
         "state": "working",
         "url": "https://github.com/labriqueinternet/piratebox_ynh"
     },

--- a/community.json
+++ b/community.json
@@ -443,7 +443,7 @@
     "hotspot": {
         "branch": "master",
         "level": 2,
-        "revision": "850f19584efe0764642587bb49ba47e73415be6b",
+        "revision": "5ee291480d4b91b136e108cac6b281b748777053",
         "state": "working",
         "url": "https://github.com/labriqueinternet/hotspot_ynh"
     },
@@ -1181,7 +1181,7 @@
     "vpnclient": {
         "branch": "master",
         "level": 1,
-        "revision": "31a0ec42c010ba5d1e8a87c2312d5eb206aac163",
+        "revision": "355b24ea0cd3467d7ba1390ab7d34dd4b2500229",
         "state": "working",
         "url": "https://github.com/labriqueinternet/vpnclient_ynh"
     },


### PR DESCRIPTION
Today a user had an issue where he manually installed an Internet Cube, did not have the list from LaBriqueInternet, but did have the community list. He tried to install hotspot_ynh and got stuck with lock issues because the commit was ~1 year old (c.f. recent commits from the Brique Camp).