### PR TITLE
Add piwigo to official list

### DIFF
--- a/community.json
+++ b/community.json
@@ -886,13 +886,6 @@
         "state": "working",
         "url": "https://github.com/labriqueinternet/piratebox_ynh"
     },
-    "piwigo": {
-        "branch": "master",
-        "level": 7,
-        "revision": "feefd7608ddbc054cbed7cab3469b94a280aa7c9",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
-    },
     "piwik": {
         "branch": "master",
         "revision": "2423bc937e6f4fd6c9476cc28355265bd357de95",

--- a/official.json
+++ b/official.json
@@ -62,6 +62,13 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
+    "piwigo": {
+        "branch": "master",
+        "level": 7,
+        "revision": "8bb53156b37b73db3bc737811fdde744b9027fa2",
+        "state": "validated",
+        "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
+    },
     "phpmyadmin": {
         "branch": "master",
         "level": 7,

--- a/official.json
+++ b/official.json
@@ -65,7 +65,7 @@
     "piwigo": {
         "branch": "master",
         "level": 7,
-        "revision": "8bb53156b37b73db3bc737811fdde744b9027fa2",
+        "revision": "46c7e7a6e3eee3c79f9ade973475145eeed85d4e",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -65,7 +65,7 @@
     "piwigo": {
         "branch": "master",
         "level": 7,
-        "revision": "356d2ab6c39f3bcc4f33d1fb06cf38ef0cd3bb82",
+        "revision": "091c3de0f86345768ad8a7bb2fe22fcface94407",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
     },

--- a/official.json
+++ b/official.json
@@ -65,7 +65,7 @@
     "piwigo": {
         "branch": "master",
         "level": 7,
-        "revision": "46c7e7a6e3eee3c79f9ade973475145eeed85d4e",
+        "revision": "356d2ab6c39f3bcc4f33d1fb06cf38ef0cd3bb82",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
     },


### PR DESCRIPTION
Following https://github.com/YunoHost-Apps/piwigo_ynh/issues/11, piwigo is ready to become an official app.