### PR TITLE
Remove old unmaintained apps

### DIFF
--- a/community.json
+++ b/community.json
@@ -536,7 +536,7 @@
         "branch": "master",
         "level": 0,
         "revision": "c0aba5c4e2232d837299fe0cba12a962dd0f3bfa",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/julienmalik/kiwiirc_ynh"
     },
     "kresus": {
@@ -564,7 +564,7 @@
         "branch": "master",
         "level": 0,
         "revision": "80e1d6681ec4f5764cfa6ab8e90538eee763784a",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/Yunohost-Apps/lektor_ynh"
     },
     "libresonic": {


### PR DESCRIPTION
KiwiIRC doesn't work and is untouched since 3 years.
Lektor since 11 months.

Let's move them in notworking.