### PR TITLE
Ampache official

### DIFF
--- a/community.json
+++ b/community.json
@@ -89,13 +89,6 @@
         "state": "notworking",
         "url": "https://github.com/zamentur/ajaxgoogleapis_ynh"
     },
-    "ampache": {
-        "branch": "master",
-        "level": 7,
-        "revision": "4340e5b57179b006bb8e67971d45011cf313e8fb",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/ampache_ynh"
-    },
     "apticron": {
         "branch": "master",
         "revision": "4fb8696bd1499caf9d7177a7bbb0ea14592331a9",

--- a/official.json
+++ b/official.json
@@ -6,6 +6,13 @@
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/agendav_ynh"
     },
+    "ampache": {
+        "branch": "master",
+        "level": 7,
+        "revision": "4340e5b57179b006bb8e67971d45011cf313e8fb",
+        "state": "validated",
+        "url": "https://github.com/YunoHost-Apps/ampache_ynh"
+    },
     "baikal": {
         "branch": "master",
         "level": 7,


### PR DESCRIPTION
Following this issue https://github.com/YunoHost-Apps/ampache_ynh/issues/21

Ampache is now ready to become an official app.