### PR TITLE
Revert "Upgrade Mattermost"

### DIFF
--- a/community.json
+++ b/community.json
@@ -631,8 +631,8 @@
     },
     "mattermost": {
         "branch": "master",
-        "level": 7,
-        "revision": "4f3040a486a6ff0fb56b12ba976bdbd207f7ea0e",
+        "level": 3,
+        "revision": "8295da93cd36c66bf27e9b0082514f1dce255ba5",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
     },


### PR DESCRIPTION
Reverts YunoHost/apps#414

It seems the upgrade fails for some users – and in the failure process, Yunohost fails to restore the previous version of the app, which has to effect to remove the app from the server :/

See https://github.com/YunoHost-Apps/mattermost_ynh/issues/90#issuecomment-361880523

@JimboJoe sorry for the noise. Can I let you merge this while I investigate the issue?