### PR TITLE
Upgrade Mattermost

### DIFF
--- a/community.json
+++ b/community.json
@@ -639,7 +639,7 @@
     "mattermost": {
         "branch": "master",
         "level": 7,
-        "revision": "8295da93cd36c66bf27e9b0082514f1dce255ba5",
+        "revision": "8101d3a67a02dd95361120b740d39994c04fbf56",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
     },


### PR DESCRIPTION
For real this time (after it was reverted in #415).

Changes:

- Upgrade to Mattermost 4.6.2
- Working backup and restore
- Systemd service
- Integration into Yunohost status panel
- Multi-instance supported
- Safer upgrade (doesn't attempt to restore an invalid backup in case of failure)