### PR TITLE
Add an other app Collabora

### DIFF
--- a/community.json
+++ b/community.json
@@ -21,9 +21,9 @@
     },
     "Collabora Online with Docker": {
         "branch": "master",
-        "revision": "2aa1d763983836934da7a88272975ee019d3f426",
+        "revision": "4ece7d8a4fb7ce745f90633c151007ac2ff81b65",
         "state": "inprogress",
-        "url": "https://github.com/aymhce/collabora_ynh"
+        "url": "https://github.com/aymhce/collaboradocker_ynh"
     },
     "Cubiks-2048": {
         "branch": "master",

--- a/community.json
+++ b/community.json
@@ -19,6 +19,12 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/collaboraonline_ynh"
     },
+    "Collabora Online with Docker": {
+        "branch": "master",
+        "revision": "2aa1d763983836934da7a88272975ee019d3f426",
+        "state": "inprogress",
+        "url": "https://github.com/aymhce/collabora_ynh"
+    },
     "Cubiks-2048": {
         "branch": "master",
         "level": 3,

--- a/community.json
+++ b/community.json
@@ -21,7 +21,7 @@
     },
     "Collabora Online with Docker": {
         "branch": "master",
-        "revision": "4ece7d8a4fb7ce745f90633c151007ac2ff81b65",
+        "revision": "27d2d16034358c6b48200d7928bad9ea0f1643dd",
         "state": "inprogress",
         "url": "https://github.com/aymhce/collaboradocker_ynh"
     },


### PR DESCRIPTION
Hello, I propose my collabora app on which I work since 2 months ... I saw that there was another one ... For me, my app work and is based on "[dockerapp-yunohost](https://github.com/aymhce/dockerappmodel_ynh/)", as portainer_ynh or yunohost_ynh. However, it will not work in CI. The linux kernel of the debian image for LXC is too old and does not contain the latest drivers necessary for the proper functioning of the app.