### PR TITLE
Use HEAD for all official apps

### DIFF
--- a/official.json
+++ b/official.json
@@ -2,35 +2,35 @@
     "agendav": {
         "branch": "master",
         "level": 0,
-        "revision": "0259831957d005c64772080c85e81b03604d760f",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/agendav_ynh"
     },
     "ampache": {
         "branch": "master",
         "level": 7,
-        "revision": "56750ddb817a323139974a59ab11cdb449f7ea5a",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/ampache_ynh"
     },
     "baikal": {
         "branch": "master",
         "level": 7,
-        "revision": "c7eefc2013e2e7b17b9fa664b375439bb96fb288",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/baikal_ynh"
     },
     "dokuwiki": {
         "branch": "master",
         "level": 4,
-        "revision": "9e34a8fce00967c8896e26017f26294022f7cbee",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
     },
     "etherpad_mypads": {
         "branch": "master",
         "level": 7,
-        "revision": "9dad23805999e230420ac6b81a27a8536013edfe",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/etherpad_mypads_ynh"
     },
@@ -44,126 +44,126 @@
     "jirafeau": {
         "branch": "master",
         "level": 3,
-        "revision": "1a3defd4d7c5d05f3cd2f5b70bc496674b7cba72",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/jirafeau_ynh"
     },
     "kanboard": {
         "branch": "master",
         "level": 7,
-        "revision": "1941a47d8b916295c1ff6e0e019f8fdf66ba4d3d",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/kanboard_ynh"
     },
     "my_webapp": {
         "branch": "master",
         "level": 7,
-        "revision": "6c3615e5b5224cc1bc12196cf0b440df9fd4ff85",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/my_webapp_ynh"
     },
     "nextcloud": {
         "branch": "master",
         "level": 7,
-        "revision": "1e35eb7e6a6d327d57c872efe65205a18d2bea3a",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
     },
     "opensondage": {
         "branch": "master",
         "level": 7,
-        "revision": "edfd98ec2f8d7714496dfe585634b3455884ab3e",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
     "phpmyadmin": {
         "branch": "master",
         "level": 7,
-        "revision": "b7d01edb9612b3791eeb97de2bf141910597a76d",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/phpmyadmin_ynh"
     },
     "piwigo": {
         "branch": "master",
         "level": 7,
-        "revision": "fe5ab39372ddbb2bb3da6a3cd1b250ae3e98b750",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
     },
     "rainloop": {
         "branch": "master",
         "level": 7,
-        "revision": "6f996f7d1d986462ef90227a5be51750bcccefa3",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/rainloop_ynh"
     },
     "roundcube": {
         "branch": "master",
         "level": 7,
-        "revision": "a1e12bcf7181447e3e0cefa9ac2a172ada21c3f9",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/roundcube_ynh"
     },
     "searx": {
         "branch": "master",
         "level": 2,
-        "revision": "d522d8dd496c92fc06b8945b73ccf2e371c15d84",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/searx_ynh"
     },
     "shellinabox": {
         "branch": "master",
         "level": 7,
-        "revision": "5e0c058e5f312d0d2cb8a2938195890cc59bca32",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/shellinabox_ynh"
     },
     "strut": {
         "branch": "master",
         "level": 0,
-        "revision": "03c3ea18cf117127749a860afe538bc6070a8e0b",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/strut_ynh"
     },
     "synapse": {
         "branch": "master",
         "level": 7,
-        "revision": "3e91f1c31620d68d5d1f5007ef690c7404aa3f7c",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/synapse_ynh"
     },
     "transmission": {
         "branch": "master",
         "level": 7,
-        "revision": "2687c4b3c405eb98171a938f8c08c23351fb2715",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/transmission_ynh"
     },
     "ttrss": {
         "branch": "master",
         "level": 7,
-        "revision": "7e22b292244af2d14d31d27562e9b6362c023454",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/ttrss_ynh"
     },
     "wallabag2": {
         "branch": "master",
         "level": 7,
-        "revision": "689e47f4c59a4e408edb5e753f6f9ec67a1426ab",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
     },
     "wordpress": {
         "branch": "master",
         "level": 7,
-        "revision": "e697540452ef428ffc60de4bab7f0d6df41e9b44",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-Apps/wordpress_ynh"
     },
     "zerobin": {
         "branch": "master",
         "level": 7,
-        "revision": "64be493f069f428800b7a6bae7ae549ec7792b82",
+        "revision": "HEAD",
         "state": "validated",
         "url": "https://github.com/YunoHost-apps/zerobin_ynh"
     }


### PR DESCRIPTION
Alright guys, it's like the 4th time recently that we have troubles because we forget to upgrade the commit in the app list and this is already something that we raised during the Brique Camp

So I'm bringing it on the table : let's get rid of this burden of "oh yes we forgot to update the commit". The process of merging things is already quite complicated between the PR review, the testing branch and the delays for merging them. We can and should get rid of this easily-forgotten step. So let's use HEAD for all official apps ...

The only small known issue is that it might trigger an update in YunoHost even if only the README got changed for instance ... but this can also be improved later (looking at the diff and not updating the commit in the built list if only the README changed). Overall that should only be a negligible issue...