### PR TITLE
Upgrade Mattermost to v4.10.0

### DIFF
--- a/community.json
+++ b/community.json
@@ -713,7 +713,7 @@
     "mattermost": {
         "branch": "master",
         "level": 7,
-        "revision": "8101d3a67a02dd95361120b740d39994c04fbf56",
+        "revision": "9689db3f012a6da499092549b3201bff8f10e6b8",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
     },


### PR DESCRIPTION
Fixes YunoHost-Apps/mattermost_ynh/issues/102

Based on https://github.com/YunoHost-Apps/mattermost_ynh/commit/9689db3f012a6da499092549b3201bff8f10e6b8. Previous Mattermost version was 4.6.1.

I'm considering switching to a `HEAD` pointer on a stable branch, but let's publish a classic style upgrade first.