### PR TITLE
Mattermost: upgrade from HEAD

### DIFF
--- a/community.json
+++ b/community.json
@@ -714,7 +714,7 @@
     "mattermost": {
         "branch": "master",
         "level": 7,
-        "revision": "9689db3f012a6da499092549b3201bff8f10e6b8",
+        "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
     },


### PR DESCRIPTION
Use the HEAD of a stable branch to signal Mattermost upgrades (cc @alexAubin).

Fix https://github.com/YunoHost-Apps/mattermost_ynh/issues/113