### PR TITLE
Lock seafile update

### DIFF
--- a/community.json
+++ b/community.json
@@ -1130,7 +1130,7 @@
     "seafile": {
         "branch": "master",
         "level": 2,
-        "revision": "HEAD",
+        "revision": "eb1059bfe2c9961ae248fddcc25521c16d09a69b",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/seafile_ynh"
     },


### PR DESCRIPTION
The CI test fail only on the official CI. This problem is NOT reproducible any other CI. So to make some test on this CI I want to avoid any update to the users