### PR TITLE
Set notworking apps

### DIFF
--- a/community.json
+++ b/community.json
@@ -1622,7 +1622,7 @@
         "branch": "master",
         "level": 0,
         "revision": "14e01a3981bde7192e100b1f9cfa50e95d6cb89b",
-        "state": "working",
+        "state": "notworking",
         "url": "https://code.ffdn.org/ljf/wifiwithme_ynh"
     },
     "wildfly": {

--- a/community.json
+++ b/community.json
@@ -177,7 +177,7 @@
         "level": 0,
         "maintained": false,
         "revision": "7f6377bd16ffe69e07a6b64e942df2a6b3e10ea1",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/cops_ynh"
     },
     "couchpotato": {
@@ -1092,7 +1092,7 @@
         "level": 0,
         "maintained": false,
         "revision": "dd78f3575b025b78bae116cc094db4d8b6fef2e2",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-apps/owncloud_ynh"
     },
     "owntracks": {
@@ -1142,7 +1142,7 @@
         "branch": "master",
         "level": 0,
         "revision": "77d8c0dfb286591f36ec2a24a30866db66e98151",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/phpldapadmin_ynh"
     },
     "phpsysinfo": {
@@ -1331,7 +1331,7 @@
         "level": 0,
         "maintained": false,
         "revision": "f5fae0ec75849a90f65b0c7d40b5f72e531a2efc",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/Kloadut/shout_ynh"
     },
     "shsd": {

--- a/community.json
+++ b/community.json
@@ -19,7 +19,7 @@
         "branch": "master",
         "level": 0,
         "revision": "4c86f7d64f3112edfb342c5439780e0ca2742dbe",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/abantecart_ynh"
     },
     "adhocserver": {
@@ -93,14 +93,14 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/borg_ynh"
     },
     "borgserver": {
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/borgserver_ynh"
     },
     "bozon": {
@@ -150,7 +150,7 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/coin_ynh"
     },
     "collabora online": {
@@ -577,7 +577,7 @@
         "branch": "master",
         "level": 0,
         "revision": "e7439b9cc48f170621ad3e8ceddbba29e0a36012",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/haste_ynh"
     },
     "headphones": {
@@ -858,7 +858,7 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/guigot/medusa_ynh"
     },
     "menu": {
@@ -1030,7 +1030,7 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/Yunohost-Apps/odoo_ynh"
     },
     "ofbiz": {
@@ -1301,7 +1301,7 @@
         "branch": "master",
         "level": 0,
         "revision": "9971b5666ed8daedda170c5c221b364ecee52215",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/scrumblr_ynh"
     },
     "seafile": {
@@ -1338,14 +1338,14 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-apps/shsd_ynh"
     },
     "shuri": {
         "branch": "master",
         "level": 0,
         "revision": "692fecea5e260a2b0cb8a61b3abdc01d55d0b724",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/shuri_ynh"
     },
     "sickbeard": {
@@ -1411,7 +1411,7 @@
     "squid3": {
         "branch": "master",
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/squid3_ynh"
     },
     "ssh_chroot_dir": {
@@ -1608,7 +1608,7 @@
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/wekan_ynh"
     },
     "wemawema": {


### PR DESCRIPTION
Cops, owncloud, phpldapadmin and shout are already unmaintained. They're also not working.

wifiwithme isn't on YunoHost-Apps organisation on github, I can't open an issue...
https://code.ffdn.org/ljf/wifiwithme_ynh/issues

Others app will be added soon at this PR.
- https://github.com/YunoHost-Apps/medusa_ynh/issues/2
- https://github.com/YunoHost-Apps/odoo_ynh/issues/10
- https://github.com/YunoHost-Apps/halcyon_ynh/issues/1
- https://github.com/YunoHost-Apps/rocketchat_ynh/issues/60
- https://github.com/YunoHost-Apps/scrumblr_ynh/issues/9
- https://github.com/YunoHost-Apps/shsd_ynh/issues/2
- https://github.com/YunoHost-Apps/shuri_ynh/issues/2
- https://github.com/YunoHost-Apps/squid3_ynh/issues/4
- https://github.com/YunoHost-Apps/wekan_ynh/issues/24
- https://github.com/YunoHost-Apps/abantecart_ynh/issues/18
- https://github.com/YunoHost-Apps/borg_ynh/issues/14
- https://github.com/YunoHost-Apps/borgserver_ynh/issues/6
- https://github.com/YunoHost-Apps/coin_ynh/issues/7
- https://github.com/YunoHost-Apps/haste_ynh/issues/10
- https://github.com/YunoHost-Apps/Webtrees_ynh/issues/3