### PR TITLE
[fix] Burry some package with no plan to be maintained

### DIFF
--- a/community.json
+++ b/community.json
@@ -45,14 +45,6 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/agora_ynh"
     },
-    "ajaxgoogleapis": {
-        "branch": "master",
-        "level": 0,
-        "maintained": false,
-        "revision": "17565a0ed6c6f617a53d36f5b91c1a7ea884a11a",
-        "state": "notworking",
-        "url": "https://github.com/zamentur/ajaxgoogleapis_ynh"
-    },
     "apticron": {
         "branch": "master",
         "maintained": false,
@@ -326,13 +318,6 @@
         "revision": "166f55711586baf65ecf5d9404e0a1a9fbc25595",
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/ethercalc_ynh"
-    },
-    "etherpadlite": {
-        "branch": "master",
-        "level": 0,
-        "revision": "3dfaa71dbadf7befa110e685935cd2350e988bb1",
-        "state": "notworking",
-        "url": "https://github.com/abeudin/etherpadlite_ynh"
     },
     "facette": {
         "branch": "master",
@@ -1127,14 +1112,6 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/osmw_ynh"
     },
-    "owncloud": {
-        "branch": "master",
-        "level": 0,
-        "maintained": false,
-        "revision": "dd78f3575b025b78bae116cc094db4d8b6fef2e2",
-        "state": "notworking",
-        "url": "https://github.com/YunoHost-apps/owncloud_ynh"
-    },
     "owntracks": {
         "branch": "master",
         "level": 7,
@@ -1378,14 +1355,6 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/shaarli_ynh"
     },
-    "shout": {
-        "branch": "master",
-        "level": 0,
-        "maintained": false,
-        "revision": "f5fae0ec75849a90f65b0c7d40b5f72e531a2efc",
-        "state": "notworking",
-        "url": "https://github.com/Kloadut/shout_ynh"
-    },
     "shsd": {
         "branch": "master",
         "level": 0,
@@ -1481,13 +1450,6 @@
         "revision": "61eb7e0c560d91c74985fef37e7dca402c67ad18",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/staticwebapp_ynh"
-    },
-    "subscribe": {
-        "branch": "master",
-        "level": 0,
-        "revision": "HEAD",
-        "state": "notworking",
-        "url": "https://github.com/YunoHost-Apps/subscribe_ynh"
     },
     "subsonic": {
         "branch": "master",


### PR DESCRIPTION
Here i suggest to remove some apps from the community list.
I have not removed jappix cause the app is working. We probably miss a way to indicate an app is deprecated.