### PR TITLE
Fix cowyo test

### DIFF
--- a/community.json
+++ b/community.json
@@ -200,8 +200,7 @@
     },
     "cowyo": {
         "branch": "master",
-        "level": 2,
-        "revision": "0ce8a8c89a42f08f82667d7764851762db55557a",
+        "revision": "ce07237e2438a29088205f8083c0d9d5c2cb3345",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/cowyo_ynh"
     },


### PR DESCRIPTION
CI was set to test subpaths, which is not possible currently with Cowyo.