### PR TITLE
Replace odoo by libreerp

### DIFF
--- a/community.json
+++ b/community.json
@@ -1052,12 +1052,12 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/nodebb_ynh"
     },
-    "odoo": {
+    "libreerp": {
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
-        "state": "inprogress",
-        "url": "https://github.com/Yunohost-Apps/odoo_ynh"
+        "state": "working",
+        "url": "https://github.com/Yunohost-Apps/libreerp_ynh"
     },
     "ofbiz": {
         "branch": "master",


### PR DESCRIPTION
As already discuss, for trademark reasons we should replace odoo package by libreerp package.