### PR TITLE
Fix some inconsistencies in app names

### DIFF
--- a/community.json
+++ b/community.json
@@ -81,7 +81,7 @@
         "maintained": false,
         "revision": "49fb42612bb37f44960b93b872f3523fa615f203",
         "state": "inprogress",
-        "url": "https://github.com/YunoHost-Apps/bicbucStriim_ynh"
+        "url": "https://github.com/YunoHost-Apps/bicbucstriim_ynh"
     },
     "bolt": {
         "branch": "master",

--- a/community.json
+++ b/community.json
@@ -81,7 +81,7 @@
         "maintained": false,
         "revision": "49fb42612bb37f44960b93b872f3523fa615f203",
         "state": "inprogress",
-        "url": "https://github.com/YunoHost-Apps/BicBucStriim_ynh"
+        "url": "https://github.com/YunoHost-Apps/bicbucStriim_ynh"
     },
     "bolt": {
         "branch": "master",
@@ -372,7 +372,7 @@
         "level": 3,
         "revision": "HEAD",
         "state": "working",
-        "url": "https://github.com/YunoHost-Apps/Firefly-III_ynh"
+        "url": "https://github.com/YunoHost-Apps/firefly-iii_ynh"
     },
     "flarum": {
         "branch": "master",
@@ -417,7 +417,7 @@
         "level": 2,
         "revision": "8093948529d73d5046baa75f726a77ae392e0ad4",
         "state": "notworking",
-        "url": "https://github.com/YunoHost-Apps/Framaforms_ynh"
+        "url": "https://github.com/YunoHost-Apps/framaforms_ynh"
     },
     "framagames": {
         "branch": "master",
@@ -709,7 +709,7 @@
         "level": 3,
         "revision": "HEAD",
         "state": "inprogress",
-        "url": "https://github.com/YunoHost-Apps/Joomla_ynh"
+        "url": "https://github.com/YunoHost-Apps/joomla_ynh"
     },
     "keeweb": {
         "branch": "master",
@@ -1597,7 +1597,7 @@
         "maintained": false,
         "revision": "815abd8720e82da346c4891515bf08fb3701b982",
         "state": "inprogress",
-        "url": "https://github.com/YunoHost-Apps/Turtl_ynh"
+        "url": "https://github.com/YunoHost-Apps/turtl_ynh"
     },
     "tyto": {
         "branch": "master",
@@ -1669,7 +1669,7 @@
         "level": 0,
         "revision": "HEAD",
         "state": "working",
-        "url": "https://github.com/YunoHost-Apps/Webtrees_ynh"
+        "url": "https://github.com/YunoHost-Apps/webtrees_ynh"
     },
     "wekan": {
         "branch": "master",
@@ -1725,7 +1725,7 @@
         "maintained": false,
         "revision": "c4ad37ea15ef00a4b1bddd8d9c38d4ecc53b301c",
         "state": "working",
-        "url": "https://github.com/YunoHost-Apps/Youtube-dl-WebUI_ynh"
+        "url": "https://github.com/YunoHost-Apps/youtube-dl-webui_ynh"
     },
     "yunofav": {
         "branch": "master",

--- a/community.json
+++ b/community.json
@@ -162,13 +162,13 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/coin_ynh"
     },
-    "collabora online with docker": {
+    "collaboradocker": {
         "branch": "master",
         "revision": "7acf7c84572734a5c6d8d396e0f01b0acf8e5bfc",
         "state": "working",
         "url": "https://github.com/aymhce/collaboradocker_ynh"
     },
-    "collabora_online": {
+    "collabora": {
         "branch": "master",
         "revision": "HEAD",
         "state": "notworking",
@@ -261,7 +261,7 @@
         "state": "inprogress",
         "url": "https://github.com/scith/docker_container_ynh"
     },
-    "dockerregistry": {
+    "docker-registry": {
         "branch": "master",
         "maintained": true,
         "revision": "HEAD",
@@ -427,7 +427,7 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/framagames_ynh"
     },
-    "freeboard.io": {
+    "freeboard": {
         "branch": "master",
         "maintained": false,
         "revision": "337111cc7e1eff33972ae7ba39db0dbcdcdd70c0",
@@ -483,7 +483,7 @@
         "state": "notworking",
         "url": "https://github.com/Kloadut/gateone_ynh"
     },
-    "ghostblog": {
+    "ghost": {
         "branch": "master",
         "level": 0,
         "revision": "HEAD",
@@ -1547,7 +1547,7 @@
         "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/teampass_ynh"
     },
-    "telegram_chatbot_ynh": {
+    "telegram_chatbot": {
         "branch": "master",
         "maintained": false,
         "revision": "fb4e8aeb0e4f34e17e7450084e4827eabfd4ce04",


### PR DESCRIPTION
Those are some fixes for the name of some apps, because it's quite annoying to have so many inconsistencies between the manifest id, the key in community.json, and the name of the git repo ...

Those should hopefully make a bit more sense ... It should supposedly be a benign change since the key in community.json is anyway a non-reliable info ... (Ideally in the longterm I wish we could just make it disappear and just use a list of dict instead of a dict of dict...)

(Note that some renaming here are to sync the name with the manifest id, which is some cases is different from the name of repo itself (sigh))