### PR TITLE
change url repo for zabbix and set revision to head

### DIFF
--- a/community.json
+++ b/community.json
@@ -1763,9 +1763,9 @@
     "zabbix": {
         "branch": "master",
         "level": 5,
-        "revision": "d00f4ea872c21ccb7b4587f15f3f0c80667cfff3",
+        "revision": "HEAD",
         "state": "working",
-        "url": "https://github.com/Mickael-Martin/zabbix_ynh"
+        "url": "https://github.com/YunoHost-Apps/zabbix_ynh"
     },
     "zeronet": {
         "branch": "master",


### PR DESCRIPTION
Hi !

Just a change of URL after migration of my app to community repo.
I set revision to HEAD to avoid pull-request at any update.
