### PR TITLE
Removing Media Drop, 

### DIFF
--- a/community.json
+++ b/community.json
@@ -877,14 +877,6 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
     },
-    "mediadrop": {
-        "branch": "master",
-        "level": 0,
-        "maintained": false,
-        "revision": "edb7662dac88072e081fc5236d2b78ef4252fa50",
-        "state": "inprogress",
-        "url": "https://github.com/YunoHost-Apps/mediadrop_ynh"
-    },
     "mediagoblin": {
         "branch": "master",
         "level": 0,


### PR DESCRIPTION
Because mediadrop_ynh isn't able to install and when removed, it also remove Yunohost App: https://github.com/YunoHost-Apps/mediadrop_ynh/issues/4