### PR TITLE
Mediadrop is broken

### DIFF
--- a/community.json
+++ b/community.json
@@ -882,8 +882,8 @@
         "branch": "master",
         "level": 0,
         "maintained": false,
-        "revision": "edb7662dac88072e081fc5236d2b78ef4252fa50",
-        "state": "inprogress",
+        "revision": "9163126ebe1cad379a453d8bb7fa2e39f259aaac",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/mediadrop_ynh"
     },
     "mediagoblin": {


### PR DESCRIPTION
Use the last commit, which fix the error with apt.
Fix #660