### PR TITLE
Add support for featured and high quality apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To become a High Quality app, a package has to follow the following rules:
 
 You can find the validation form used by Apps group [here](https://github.com/YunoHost/apps/blob/master/hq_validation_template.md).
 
-If the app is already tag as High Quality and one of those criteria isn't respected anymore. After a warning, the tag will be removed until the criteria are again validated.
+If the app is already tagged as High Quality and one of those criteria isn't respected anymore: after a warning, the tag will be removed until the criterion is again validated.
 
 To make an app a High Quality app, technically, you have to add the tag ```"high_quality": true```.
 ```json

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To make an app a High Quality app, technically, you have to add the tag ```"high
 
 ### How to make my app a Featured app ?
 
-A Featured app highlighted in the app list and shown before any others.  
+A Featured app is highlighted in the app list and shown before any others.  
 To become a Featured app, a package have to follow the following rules:
 
 * The app should already be a High Quality app.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This tag can have 5 different values:
 - `"maintained": "request_help"` Use that value to inform other packagers that you need help to maintain this app. You'll then be more than one maintainer for this apps.
 - `"maintained": "request_adoption"` Use that value to inform other packagers, as well as users, that you're going to give up that app. So that you would like another maintainer to take care of it.
 - `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself/herself as its new maintainer.  
-Please contact Apps group if you want to take back a unmaintained app.
+Please contact Apps group if you want to take back an unmaintained app.
 
 If you want to modify the status of one of your apps, for any reason, please think also to inform the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This tag can have 5 different values:
 - `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself/herself as its new maintainer.  
 Please contact the Apps group if you want to take care of an unmaintained app.
 
-If you want to modify the status of one of your apps, for any reason, please think also to inform the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.
+If you want to modify the status of one of your apps, for any reason, please consider informing the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.
 
 #### More information
 See [yunohost.org/packaging_apps](https://yunohost.org/packaging_apps)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This tag can have 5 different values:
 - `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself as its new maintainer.  
 Please contact Apps group if you want to take back a unmaintained app.
 
-If you want to modify the status of one of your app, for any reason, please think also to inform the community via the forum. Users would probably be glad to be inform that an app they use will be unmaintained.
+If you want to modify the status of one of your apps, for any reason, please think also to inform the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.
 
 #### More information
 See [yunohost.org/packaging_apps](https://yunohost.org/packaging_apps)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To become a Featured app, a package have to follow the following rules:
 
 **Please note that the exact process to decide which app are going to be Featured, and for how many time, isn't yet defined...**
 
-To make an app a High Quality app, technically, you have to add the tag ```"featured": true```.
+To make an app a Featured app, technically, you have to add the tag ```"featured": true```.
 ```json
     "wallabag": {
         "branch": "master",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ sudo yunohost app fetchlist -n community -u https://yunohost.org/community.json
 * Fork and edit the [community list](https://github.com/YunoHost/apps/tree/master/community.json)
 * Add your app's ID and git information at the right alphabetical place
 * Indicate the app's functioning state: `notworking`, `inprogress`, or `working`
+* Do not add the level yourself. The CI will do it.
 * Send a [Pull Request](https://github.com/YunoHost/apps/pulls/)
 
 App example addition:
@@ -67,6 +68,31 @@ Usage:
 
 ```bash
 ./add_or_update.py [community.json OR official.json] [github/gitlab url OR app name [github/gitlab url OR app name [github/gitlab url OR app name ...]]]
+```
+
+### How to make my app a Featured app
+
+A featured app will be highlighted in the community list as a high quality app.  
+To become a Featured app, a package have to follow the following rules:
+
+* The app should already be in the community list for 2 months.
+* The app should be keep up to date, regarding the upstream source. (If it’s possible with our current YunoHost version)
+* The package itself should be up to date regarding the packaging recommendations and helpers.
+* The package should be level 7, at least.
+* The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
+* Any modification should be done to the testing branch, and wait at least for one approval for one member of the Apps group. So that we can ensure that there’s nothing in opposition to those criteria. Nor any changes that would harm servers.
+
+If the app is already tag as Featured and one of those criteria isn't respected anymore. After a warning, the tag will be removed until the criteria are again validated.
+
+To make an app a Featured app, technically, you have to add the tag ```"featured": true```.
+```json
+    "wallabag": {
+        "branch": "master",
+        "featured": true,
+        "revision": "c2fc62438ac5c9503e3f4ebfdc425ec03a0ec0c0",
+        "url": "https://github.com/abeudin/wallabag_ynh.git",
+        "state": "working"
+    }
 ```
 
 #### More information

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Usage:
 ### How to make my app a High Quality app ?
 
 A High Quality app will be highlighted in the app list and marked as a level 8 app.  
-To become a High Quality app, a package have to follow the following rules:
+To become a High Quality app, a package has to follow the following rules:
 
 * The app should already be in the community list for 2 months.
 * The app should be keep up to date, regarding the upstream source. (If it’s possible with our current YunoHost version)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A High Quality app will be highlighted in the app list and marked as a level 8 a
 To become a High Quality app, a package has to follow the following rules:
 
 * The app should already have been in the community list for 2 months.
-* The app should be keep up to date, regarding the upstream source. (If it’s possible with our current YunoHost version)
+* The app should be kept up to date, regarding the upstream source (if it’s possible with our current YunoHost version).
 * The package itself should be up to date regarding the packaging recommendations and helpers.
 * The package should be level 7, at least.
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To become a Featured app, a package has to follow the following rules:
 * The app should be interesting and demanded by the community.
 * The app should fit the spirit of YunoHost.
 
-**Please note that the exact process to decide which app are going to be Featured, and for how many time, isn't yet defined...**
+**Please note that the exact process to decide which apps are going to be Featured, and for how many time, isn't yet defined...**
 
 To make an app a Featured app, technically, you have to add the tag ```"featured": true```.
 ```json

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Usage:
 
 ### How to make my app a High Quality app ?
 
-A High Quality app will be highlighted in the app list and mark as a level 8 app.  
+A High Quality app will be highlighted in the app list and marked as a level 8 app.  
 To become a High Quality app, a package have to follow the following rules:
 
 * The app should already be in the community list for 2 months.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This tag can have 5 different values:
 - `"maintained": "request_help"` Use that value to inform other packagers that you need help to maintain this app. You'll then be more than one maintainer for this apps.
 - `"maintained": "request_adoption"` Use that value to inform other packagers, as well as users, that you're going to give up that app. So that you would like another maintainer to take care of it.
 - `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself/herself as its new maintainer.  
-Please contact Apps group if you want to take back an unmaintained app.
+Please contact the Apps group if you want to take care of an unmaintained app.
 
 If you want to modify the status of one of your apps, for any reason, please think also to inform the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To make an app a High Quality app, technically, you have to add the tag ```"high
 ### How to make my app a Featured app ?
 
 A Featured app is highlighted in the app list and shown before any others.  
-To become a Featured app, a package have to follow the following rules:
+To become a Featured app, a package has to follow the following rules:
 
 * The app should already be a High Quality app.
 * The upstream app should be accessible and well made.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Usage:
 A High Quality app will be highlighted in the app list and marked as a level 8 app.  
 To become a High Quality app, a package has to follow the following rules:
 
-* The app should already be in the community list for 2 months.
+* The app should already have been in the community list for 2 months.
 * The app should be keep up to date, regarding the upstream source. (If it’s possible with our current YunoHost version)
 * The package itself should be up to date regarding the packaging recommendations and helpers.
 * The package should be level 7, at least.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Usage:
 ./add_or_update.py [community.json OR official.json] [github/gitlab url OR app name [github/gitlab url OR app name [github/gitlab url OR app name ...]]]
 ```
 
-### How to make my app a Featured app
+### How to make my app a High Quality app ?
 
-A featured app will be highlighted in the community list as a high quality app.  
-To become a Featured app, a package have to follow the following rules:
+A High Quality app will be highlighted in the app list and mark as a level 8 app.  
+To become a High Quality app, a package have to follow the following rules:
 
 * The app should already be in the community list for 2 months.
 * The app should be keep up to date, regarding the upstream source. (If it’s possible with our current YunoHost version)
@@ -82,14 +82,38 @@ To become a Featured app, a package have to follow the following rules:
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
 * Any modification should be done to the testing branch, and wait at least for one approval for one member of the Apps group. So that we can ensure that there’s nothing in opposition to those criteria. Nor any changes that would harm servers.
 
-If the app is already tag as Featured and one of those criteria isn't respected anymore. After a warning, the tag will be removed until the criteria are again validated.
+If the app is already tag as High Quality and one of those criteria isn't respected anymore. After a warning, the tag will be removed until the criteria are again validated.
 
-To make an app a Featured app, technically, you have to add the tag ```"featured": true```.
+To make an app a High Quality app, technically, you have to add the tag ```"high_quality": true```.
 ```json
     "wallabag": {
         "branch": "master",
+        "high_quality": true,
+        "revision": HEAD,
+        "url": "https://github.com/abeudin/wallabag_ynh.git",
+        "state": "working"
+    }
+```
+
+### How to make my app a Featured app ?
+
+A Featured app highlighted in the app list and shown before any others.  
+To become a Featured app, a package have to follow the following rules:
+
+* The app should already be a High Quality app.
+* The upstream app should be accessible and well made.
+* The app should be interesting and demanded by the community.
+* The app should fit the spirit of YunoHost.
+
+**Please note that the exact process to decide which app are going to be Featured, and for how many time, isn't yet defined...**
+
+To make an app a High Quality app, technically, you have to add the tag ```"featured": true```.
+```json
+    "wallabag": {
+        "branch": "master",
+        "high_quality": true,
         "featured": true,
-        "revision": "c2fc62438ac5c9503e3f4ebfdc425ec03a0ec0c0",
+        "revision": HEAD,
         "url": "https://github.com/abeudin/wallabag_ynh.git",
         "state": "working"
     }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ To become a High Quality app, a package have to follow the following rules:
 * The package should be level 7, at least.
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
 * Any modification should be done to the testing branch, and wait at least for one approval for one member of the Apps group. So that we can ensure that there’s nothing in opposition to those criteria. Nor any changes that would harm servers.
+* The package should comply with the [requirement of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).
+
+You can find the validation form used by Apps group [here](https://github.com/YunoHost/apps/blob/master/hq_validation_template.md).
 
 If the app is already tag as High Quality and one of those criteria isn't respected anymore. After a warning, the tag will be removed until the criteria are again validated.
 

--- a/README.md
+++ b/README.md
@@ -119,5 +119,18 @@ To make an app a Featured app, technically, you have to add the tag ```"featured
     }
 ```
 
+### What to do if I can't maintain my app anymore ?
+
+If you don't have time anymore to maintain an app, you can update its status to inform users and packagers that you will not maintain it anymore.  
+In order to do so, use the tag `"maintained":`.  
+This tag can have 5 different values:
+- `"maintained": true` That's the default value if the tag isn't present for your app. That simply means that this app is maintained.
+- `"maintained": "request_help"` Use that value to inform other packagers that you need help to maintain this app. You'll then be more than one maintainer for this apps.
+- `"maintained": "request_adoption"` Use that value to inform other packagers, as well as users, that you're going to give up that app. So that you would like another maintainer to take care of it.
+- `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself as its new maintainer.  
+Please contact Apps group if you want to take back a unmaintained app.
+
+If you want to modify the status of one of your app, for any reason, please think also to inform the community via the forum. Users would probably be glad to be inform that an app they use will be unmaintained.
+
 #### More information
 See [yunohost.org/packaging_apps](https://yunohost.org/packaging_apps)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To become a High Quality app, a package has to follow the following rules:
 * The package should be level 7, at least.
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
 * Any modification should be done to the testing branch, and wait at least for one approval of one member of the Apps group so that we can ensure that there’s nothing in opposition to those criteria, nor any changes that would harm servers.
-* The package should comply with the [requirement of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).
+* The package should comply with the [requirements of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).
 
 You can find the validation form used by Apps group [here](https://github.com/YunoHost/apps/blob/master/hq_validation_template.md).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To become a High Quality app, a package has to follow the following rules:
 * The app should already have been in the community list for 2 months.
 * The app should be kept up to date, regarding the upstream source (if it’s possible with our current YunoHost version).
 * The package itself should be up to date regarding the packaging recommendations and helpers.
-* The package should be level 7, at least.
+* The package should be level 7 for at least 1 month.
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
 * Any modification should be done to the testing branch, and wait at least for one approval of one member of the Apps group so that we can ensure that there’s nothing in opposition to those criteria, nor any changes that would harm servers.
 * The package should comply with the [requirements of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This tag can have 5 different values:
 - `"maintained": true` That's the default value if the tag isn't present for your app. That simply means that this app is maintained.
 - `"maintained": "request_help"` Use that value to inform other packagers that you need help to maintain this app. You'll then be more than one maintainer for this apps.
 - `"maintained": "request_adoption"` Use that value to inform other packagers, as well as users, that you're going to give up that app. So that you would like another maintainer to take care of it.
-- `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself as its new maintainer.  
+- `"maintained": false` or `"maintained": "orphaned"` This value means that this app is no longer maintained... That means also that a packager can declare himself/herself as its new maintainer.  
 Please contact Apps group if you want to take back a unmaintained app.
 
 If you want to modify the status of one of your apps, for any reason, please think also to inform the community via the forum. Users would probably be glad to be informed that an app they use will become unmaintained.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To become a High Quality app, a package has to follow the following rules:
 * The package itself should be up to date regarding the packaging recommendations and helpers.
 * The package should be level 7, at least.
 * The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
-* Any modification should be done to the testing branch, and wait at least for one approval for one member of the Apps group. So that we can ensure that there’s nothing in opposition to those criteria. Nor any changes that would harm servers.
+* Any modification should be done to the testing branch, and wait at least for one approval of one member of the Apps group so that we can ensure that there’s nothing in opposition to those criteria, nor any changes that would harm servers.
 * The package should comply with the [requirement of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).
 
 You can find the validation form used by Apps group [here](https://github.com/YunoHost/apps/blob/master/hq_validation_template.md).

--- a/app_levels/en.json
+++ b/app_levels/en.json
@@ -8,6 +8,6 @@
     "applevel_6":  "Available for the community",
     "applevel_7":  "Successfully pass functional tests",
     "applevel_8":  "High quality app",
-    "applevel_9":  "Respect highter guidelines",
+    "applevel_9":  "Respect higher guidelines",
     "applevel_10": "Package assessed as perfect"
 }

--- a/app_levels/en.json
+++ b/app_levels/en.json
@@ -5,7 +5,7 @@
     "applevel_3":  "Can be updated",
     "applevel_4":  "Backup and restore support",
     "applevel_5":  "Clean",
-    "applevel_6":  "Available for the community",
+    "applevel_6":  "Open to contributions from the community",
     "applevel_7":  "Successfully pass functional tests",
     "applevel_8":  "High quality app",
     "applevel_9":  "Respect higher guidelines",

--- a/app_levels/en.json
+++ b/app_levels/en.json
@@ -3,11 +3,11 @@
     "applevel_1":  "Installable",
     "applevel_2":  "Installable in all situations",
     "applevel_3":  "Can be updated",
-    "applevel_4":  "Single Sign On support",
+    "applevel_4":  "Backup and restore support",
     "applevel_5":  "Clean",
-    "applevel_6":  "Backup and restore support",
+    "applevel_6":  "Available for the community",
     "applevel_7":  "Successfully pass functional tests",
-    "applevel_8":  "Respect main guidelines",
-    "applevel_9":  "Respect all guidelines",
+    "applevel_8":  "High quality app",
+    "applevel_9":  "Respect highter guidelines",
     "applevel_10": "Package assessed as perfect"
 }

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -9,7 +9,7 @@ Mandatory check boxes:
 - [ ] The package is up to date regarding the packaging recommendations and helpers.
 - [ ] The repository has a testing branch.
 - [ ] All commits are made in testing branch before being merged into master.
-- [ ] The list point to HEAD, not a specific commit.
+- [ ] The list points to HEAD, not to a specific commit.
 - [ ] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md)
 - [ ] The package shows the YunoHost tile `yunohost_panel.conf.inc`
 

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -5,7 +5,7 @@ This template is designed to be used as it is by Apps group to validate requests
 Mandatory check boxes:
 - [ ] The package is level 7.
 - [ ] The package has been level 7 for at least 2 months.
-- [ ] The package is in the list since at least 2 months.
+- [ ] The package has been in the list for at least 2 months.
 - [ ] The package is up to date regarding the packaging recommendations and helpers.
 - [ ] The repository has a testing branch.
 - [ ] All commits are made in testing branch before being merged into master.

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -4,7 +4,7 @@ This template is designed to be used as it is by Apps group to validate requests
 
 Mandatory check boxes:
 - [ ] The package is level 7.
-- [ ] The package has been level 7 for at least 2 months.
+- [ ] The package has been level 7 for at least 1 month.
 - [ ] The package has been in the list for at least 2 months.
 - [ ] The package is up to date regarding the packaging recommendations and helpers.
 - [ ] The repository has a testing branch.

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -1,0 +1,24 @@
+# Validation template for High Quality tag request
+
+This template is designed to be used as it is by Apps group to validate requests from packagers for the tag High Quality.
+
+Mandatory check boxes:
+- [ ] The package is level 7.
+- [ ] The package is level 7 since at least 2 months.
+- [ ] The package is in the list since at least 2 months.
+- [ ] The package is up to date regarding the packaging recommendations and helpers.
+- [ ] The repository has a testing branch.
+- [ ] All commits are made in testing branch before being merged into master.
+- [ ] The list point to HEAD, not a specific commit.
+- [ ] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md)
+- [ ] The package shows the YunoHost tile `yunohost_panel.conf.inc`
+
+Optional check boxes:
+- [ ] The package is level 7 for ARM as well.
+*If the app is really important for the community, we can accept it with a broken ARM support. But this should be clearly explained and managed.*
+- [ ] The app is up to date with the upstream version.  
+*If this is possible with the last YunoHost version.*
+- [ ] The package supports LDAP  
+*If the app upstream supports it*
+- [ ] The package supports HTTP authentication  
+*If the app upstream supports it*

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -4,7 +4,7 @@ This template is designed to be used as it is by Apps group to validate requests
 
 Mandatory check boxes:
 - [ ] The package is level 7.
-- [ ] The package is level 7 since at least 2 months.
+- [ ] The package has been level 7 for at least 2 months.
 - [ ] The package is in the list since at least 2 months.
 - [ ] The package is up to date regarding the packaging recommendations and helpers.
 - [ ] The repository has a testing branch.

--- a/list_builder.py
+++ b/list_builder.py
@@ -145,6 +145,7 @@ for app, info in apps_list.items():
     app_state = info["state"]
     app_level = info.get("level")
     app_maintained = info.get("maintained", True)
+    app_featured = info.get("featured", False)
 
     forge_site = app_url.split('/')[2]
     owner = app_url.split('/')[3]
@@ -167,6 +168,7 @@ for app, info in apps_list.items():
     previous_url = already_built_file.get(app, {}).get("git", {}).get("url")
     previous_level = already_built_file.get(app, {}).get("level")
     previous_maintained = already_built_file.get(app, {}).get("maintained")
+    previous_featured = already_built_file.get(app, {}).get("featured")
 
     if forge_type == "github" and app_rev == "HEAD":
 
@@ -210,6 +212,9 @@ for app, info in apps_list.items():
         if previous_maintained != app_maintained:
             result_dict[app]["maintained"] = app_maintained
             print("... but maintained status changed, updating it from '%s' to '%s'" % (previous_maintained, app_maintained))
+        if previous_featured != app_featured:
+            result_dict[app]["featured"] = app_featured
+            print("... but featured status changed, updating it from '%s' to '%s'" % (previous_featured, app_featured))
 
         print "update translations but don't download anything"
         result_dict[app]['manifest'] = include_translations_in_manifest(app, result_dict[app]['manifest'])
@@ -318,7 +323,8 @@ for app, info in apps_list.items():
             'manifest': include_translations_in_manifest(manifest['id'], manifest),
             'state': info['state'],
             'level': info.get('level', '?'),
-            'maintained': app_maintained
+            'maintained': app_maintained,
+            'featured': app_featured
         }
     except KeyError as e:
         print("-> Error: invalid app info or manifest, %s" % e)

--- a/list_builder.py
+++ b/list_builder.py
@@ -146,6 +146,7 @@ for app, info in apps_list.items():
     app_level = info.get("level")
     app_maintained = info.get("maintained", True)
     app_featured = info.get("featured", False)
+    app_high_quality = info.get("high_quality", False)
 
     forge_site = app_url.split('/')[2]
     owner = app_url.split('/')[3]
@@ -169,6 +170,7 @@ for app, info in apps_list.items():
     previous_level = already_built_file.get(app, {}).get("level")
     previous_maintained = already_built_file.get(app, {}).get("maintained")
     previous_featured = already_built_file.get(app, {}).get("featured")
+    previous_high_quality = already_built_file.get(app, {}).get("high_quality")
 
     if forge_type == "github" and app_rev == "HEAD":
 
@@ -215,6 +217,9 @@ for app, info in apps_list.items():
         if previous_featured != app_featured:
             result_dict[app]["featured"] = app_featured
             print("... but featured status changed, updating it from '%s' to '%s'" % (previous_featured, app_featured))
+        if previous_high_quality != app_high_quality:
+            result_dict[app]["high_quality"] = app_high_quality
+            print("... but high_quality status changed, updating it from '%s' to '%s'" % (previous_high_quality, app_high_quality))
 
         print "update translations but don't download anything"
         result_dict[app]['manifest'] = include_translations_in_manifest(app, result_dict[app]['manifest'])
@@ -324,6 +329,7 @@ for app, info in apps_list.items():
             'state': info['state'],
             'level': info.get('level', '?'),
             'maintained': app_maintained,
+            'high_quality': app_high_quality,
             'featured': app_featured
         }
     except KeyError as e:

--- a/pull_request_template-HQ-apps.md
+++ b/pull_request_template-HQ-apps.md
@@ -17,7 +17,7 @@
 - [ ] **Approval (LGTM)**  
 *Code review and approval have to be from a member of @YunoHost/apps group*
 - **CI succeeded** : 
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/)  
+[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/APP_ynh%20-BRANCH-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/APP_ynh%20-BRANCH-/)  
 *Please replace '-BRANCH-' in this link by the name of the branch used.*  
 *If the PR is from a forked repository. Please provide public results from package_check.*  
 When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.

--- a/pull_request_template-HQ-apps.md
+++ b/pull_request_template-HQ-apps.md
@@ -1,0 +1,23 @@
+## Problem
+- *Description of why you made this PR*
+
+## Solution
+- *And how do you fix that problem*
+
+## PR Status
+- [ ] Code finished.
+- [ ] Tested with Package_check.
+- [ ] Fix or enhancement tested.
+- [ ] Upgrade from last version tested.
+- [ ] Can be reviewed and tested.
+
+## Validation
+---
+- [ ] **Code review**
+- [ ] **Approval (LGTM)**  
+*Code review and approval have to be from a member of @YunoHost/apps group*
+- **CI succeeded** : 
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/)  
+*Please replace '-BRANCH-' in this link by the name of the branch used.*  
+*If the PR is from a forked repository. Please provide public results from package_check.*  
+When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.


### PR DESCRIPTION
Replace https://github.com/YunoHost/apps/pull/655 with a tag in the community list instead of a new list.
Related to https://github.com/YunoHost/yunohost-admin/pull/225 to manage the tag in the app list.

For all who'd worried that I really modify python code. Don't worry, I wasn't alone to do it.
![](https://crudelis.fr/lutim/Xb7FAYk7/kMudm5jY)

The discussion about this feature is [here](https://forum.yunohost.org/t/about-community-and-official-apps/6372). Nothing has been decided yet, still I go forward to propose some concrete work.
I especially would like to have the point of view of the @YunoHost/apps group, since we would be concerned as we would have to give a quick review to each PR on those apps.

---

EDIT

During our last meeting it was decided:

- In a mid-long term, get rid of Official and Community list, and merge into one unique list.
Let's say simply "One list to rule them all, One list to find them; One list to bring them all and [...]." Don't remember the end of this sentence... Never mind...
- Add a status of the maintained state of an app. Like the way Debian do it. ‘Orphaned’, ‘Request for Adoption’, ‘Request For Help’.
- Keep 'Featured apps' as apps highlighted for editorial reasons. Maybe via a poll on the forum, not defined yet.
- Adapt level 8 for high quality apps. Validated by Apps group.
- Modify level 4, to not block apps anymore under level 3 because of ldap or SSO.

Related PR:
Those PR should be merged in that order to not break anything.
- This very PR should be merged first.
- ~Add High Quality tag for some apps [#678](https://github.com/YunoHost/apps/pull/678)~
- Modify levels 4, 6 and 8 [#52](https://github.com/YunoHost/package_check/pull/52)
- Add YEP 1.12 - Follow example_ynh [#935](https://github.com/YunoHost/doc/pull/935)
- Update packaging_apps_levels.md [#927](https://github.com/YunoHost/doc/pull/927)
- Add support for featured community apps [#225](https://github.com/YunoHost/yunohost-admin/pull/225)
- Merge Official and Community into Apps [#694](https://github.com/YunoHost/apps/pull/694)
- Migrate to apps.json [#5](https://github.com/YunoHost/yunorunner/pull/5)
- Use apps.json as default list [#665](https://github.com/YunoHost/yunohost/pull/665)
-  Migrate to apps.json [#666](https://github.com/YunoHost/yunohost/pull/666)
- Get apps from apps.json instead of community and official [#13](https://github.com/YunoHost/CI_package_check/pull/13)

TODO list:
- ~Add a filter for High Quality apps in to yunohost admin app list~
- ~Add support for maintained states in yunohost-admin~
- ~Update readme to explain how to use maintained states~
- ~Update package_check to read the value of high_quality into the app list.~
- ~Create a new list for all apps.~
- ~Handle that list with list_builder.~
- ~Update CI to handle that new list.~
- Update the documentation. (Sorry lazy on that part...)
- ~Use automatically that list, instead of the Official one.~
- ~Add a migration to remove the Official list an use the new one instead.~
- Merge all that mess.
- Enjoy \o/

**This PR is still waiting for a global acceptance from the @YunoHost/apps group.**