### PR TITLE
Add High Quality tag for some apps

### DIFF
--- a/community.json
+++ b/community.json
@@ -53,6 +53,7 @@
     "archivist": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/archivist_ynh"
@@ -113,6 +114,7 @@
     "cachet": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/cachet_ynh"
@@ -347,6 +349,7 @@
     "fallback": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/fallback_ynh"
@@ -444,6 +447,7 @@
     "friendica": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/friendica_ynh"
@@ -472,6 +476,7 @@
     "garradin": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/garradin_ynh"
@@ -644,6 +649,7 @@
     "hubzilla": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/hubzilla_ynh"
@@ -775,6 +781,7 @@
     "leed": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/leed_ynh"
@@ -838,6 +845,7 @@
     "lutim": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/lutim_ynh"
@@ -934,6 +942,7 @@
     "minidlna": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/minidlna_ynh"
@@ -1000,6 +1009,7 @@
     "multi_webapp": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/multi_webapp_ynh"
@@ -1210,6 +1220,7 @@
     "pihole": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/pihole_ynh"
@@ -1620,6 +1631,7 @@
     "unattended_upgrades": {
         "branch": "master",
         "level": 7,
+        "featured": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/unattended_upgrades_ynh"

--- a/community.json
+++ b/community.json
@@ -52,8 +52,8 @@
     },
     "archivist": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/archivist_ynh"
@@ -113,8 +113,8 @@
     },
     "cachet": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/cachet_ynh"
@@ -348,8 +348,8 @@
     },
     "fallback": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/fallback_ynh"
@@ -446,8 +446,8 @@
     },
     "friendica": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/friendica_ynh"
@@ -475,8 +475,8 @@
     },
     "garradin": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/garradin_ynh"
@@ -648,8 +648,8 @@
     },
     "hubzilla": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/hubzilla_ynh"
@@ -780,8 +780,8 @@
     },
     "leed": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/leed_ynh"
@@ -844,8 +844,8 @@
     },
     "lutim": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/lutim_ynh"
@@ -941,8 +941,8 @@
     },
     "minidlna": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/minidlna_ynh"
@@ -1008,8 +1008,8 @@
     },
     "multi_webapp": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/multi_webapp_ynh"
@@ -1219,8 +1219,8 @@
     },
     "pihole": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/pihole_ynh"
@@ -1630,8 +1630,8 @@
     },
     "unattended_upgrades": {
         "branch": "master",
-        "level": 7,
-        "featured": true,
+        "level": 8,
+        "high_quality": true,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/unattended_upgrades_ynh"


### PR DESCRIPTION
Following https://github.com/YunoHost/apps/pull/677, here a proposition for some apps which can be the first to be tag as Featured. So we could start the new feature.
That's only a proposition to begin with this new tag.

Those apps are only apps maintained by members of apps group, considering that one of the requirement is to accept that the group will have a look to each PR. It seems to me that it would be better to start with apps from the group itself.
Obviously one would notice that most of them are my own apps. Indeed, I don't need a long and harassing review to know what the status of my own apps. And I know that they already respect the requirements.
Also, I intentionally removed apps which used too much factorization in _common.sh, since I'm again such way to code apps here. I'm still in favor of keeping scripts clear and simple, and to stick to the template.

I notice also that [cachet](https://github.com/YunoHost-Apps/cachet_ynh), [garradin](https://github.com/YunoHost-Apps/garradin_ynh) and [hubzilla](https://github.com/YunoHost-Apps/hubzilla_ynh) miss a testing branch.

This PR is only a proposition to start a list of Featured apps. It could be discussed.
And, finally, this PR has only a meaning if https://github.com/YunoHost/apps/pull/677 and the global idea of this tag is accepted.

**This PR should be merged after https://github.com/YunoHost/apps/pull/677**