### PR TITLE
Hotspot should now be working again (on the CI)

### DIFF
--- a/community.json
+++ b/community.json
@@ -622,8 +622,8 @@
     "hotspot": {
         "branch": "master",
         "level": 0,
-        "revision": "5ee291480d4b91b136e108cac6b281b748777053",
-        "state": "inprogress",
+        "revision": "HEAD",
+        "state": "working",
         "url": "https://github.com/labriqueinternet/hotspot_ynh"
     },
     "htmltool": {


### PR DESCRIPTION
Following https://github.com/labriqueinternet/hotspot_ynh/pull/31 and other commits