### PR TITLE
filebin removal

### DIFF
--- a/community.json
+++ b/community.json
@@ -360,14 +360,6 @@
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/ffsync_ynh"
     },
-    "filebin": {
-        "branch": "master",
-        "level": 2,
-        "maintained": false,
-        "revision": "9caf60447be803386890960f11e973daa2ab936a",
-        "state": "working",
-        "url": "https://github.com/IsserTerrus/filebin_ynh"
-    },
     "firefly-iii": {
         "branch": "master",
         "level": 3,


### PR DESCRIPTION
I propose to remove filebin:

- Yunohost Package no more maintained
- Upstream application is not maintained since more than 5 years : https://github.com/sebsauvage/ZeroBin
- The maintainer of the upstreamapplication advises to use PrivateBin https://sebsauvage.net/wiki/doku.php?id=php:zerobin
- PrivateBin is already a Yunohost package named: zerobin => https://github.com/YunoHost-Apps/zerobin_ynh
