### PR TITLE
Merge Official and Community into Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ https://yunohost.org/apps
 
  - **official.json** contains the repository information of validated apps.
  - **community.json** contains all references to known YunoHost packages. If you want to add your app to the list, please [send a Pull Request](#contributing)
- - **apps.json** contains all references to known YunoHost packages. If you want to add your app to the list, please [send a Pull Request](#contributing). This list replace both community.json and official.json.
+ - **apps.json** contains all references to known YunoHost packages. If you want to add your app to the list, please [send a Pull Request](#contributing). **This list replace both community.json and official.json.**
 
 
 ## Usage
 
-The official package list is automatically fetched. If you want to **enable the community package list** on your YunoHost instance:
+The official package list is automatically fetched. If you want to **enable the apps package list** on your YunoHost instance:
 ```
-sudo yunohost app fetchlist -n community -u https://yunohost.org/community.json
+sudo yunohost app fetchlist -n apps -u https://yunohost.org/apps.json
 ```
 
 
@@ -67,7 +67,7 @@ your app from one of the 2 json files.
 Usage:
 
 ```bash
-./add_or_update.py [community.json OR official.json] [github/gitlab url OR app name [github/gitlab url OR app name [github/gitlab url OR app name ...]]]
+./add_or_update.py apps.json [github/gitlab url OR app name [github/gitlab url OR app name [github/gitlab url OR app name ...]]]
 ```
 
 #### More information

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://yunohost.org/apps
 
  - **official.json** contains the repository information of validated apps.
  - **community.json** contains all references to known YunoHost packages. If you want to add your app to the list, please [send a Pull Request](#contributing)
+ - **apps.json** contains all references to known YunoHost packages. If you want to add your app to the list, please [send a Pull Request](#contributing). This list replace both community.json and official.json.
 
 
 ## Usage
@@ -35,9 +36,9 @@ sudo yunohost app fetchlist -n community -u https://yunohost.org/community.json
 
 ## Contributing
 
-### How to add your app to the community list
+### How to add your app to the apps list
 
-* Fork and edit the [community list](https://github.com/YunoHost/apps/tree/master/community.json)
+* Fork and edit the [apps list](https://github.com/YunoHost/apps/tree/master/apps.json)
 * Add your app's ID and git information at the right alphabetical place
 * Indicate the app's functioning state: `notworking`, `inprogress`, or `working`
 * Send a [Pull Request](https://github.com/YunoHost/apps/pulls/)

--- a/apps.json
+++ b/apps.json
@@ -1,0 +1,1989 @@
+{
+    "20euros": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "c8d5fadc9f042a92f14b753eff3ffc948322cf2d",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/20euros_ynh"
+    },
+    "243": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "b9d58efeac78feb7f74e723c999ff25ab7ab8b52",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/243_ynh"
+    },
+    "abantecart": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/abantecart_ynh"
+    },
+    "adhocserver": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "d1a728b9b99608bac69b55372cddf1aa3f4a5557",
+        "state": "inprogress",
+        "url": "https://github.com/matlink/adhocserver_ynh"
+    },
+    "adminer": {
+        "branch": "master",
+        "level": 1,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/adminer_ynh"
+    },
+    "agendav": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/agendav_ynh"
+    },
+    "agora": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/agora_ynh"
+    },
+    "airsonic": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/airsonic_ynh"
+    },
+    "ampache": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/ampache_ynh"
+    },
+    "apticron": {
+        "branch": "master",
+        "maintained": false,
+        "revision": "4fb8696bd1499caf9d7177a7bbb0ea14592331a9",
+        "state": "inprogress",
+        "url": "https://github.com/ldidry/apticron_ynh"
+    },
+    "archivist": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/archivist_ynh"
+    },
+    "askbot": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "334914395f5a22b94e3628f5e6ad45dddd89c2d6",
+        "state": "inprogress",
+        "url": "https://github.com/zamentur/askbot_ynh"
+    },
+    "baikal": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/baikal_ynh"
+    },
+    "bicbucstriim": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "49fb42612bb37f44960b93b872f3523fa615f203",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/bicbucstriim_ynh"
+    },
+    "bolt": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "94ecae64d4fcdee8e65128d8d277b48d50e6ebe2",
+        "state": "inprogress",
+        "url": "https://github.com/realitygaps/bolt_ynh"
+    },
+    "borg": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/borg_ynh"
+    },
+    "borgserver": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/borgserver_ynh"
+    },
+    "bozon": {
+        "branch": "master",
+        "level": 7,
+        "revision": "9cf9c46f94b41ed8a6784ba8f8eac39e3991ab07",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/bozon_ynh"
+    },
+    "btsync": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "1fb778d872c460e2fc7ba02ed4b9f7bef8a4584e",
+        "state": "inprogress",
+        "url": "https://github.com/drfred1981/btsync_ynh"
+    },
+    "cachet": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/cachet_ynh"
+    },
+    "calibreweb": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/calibre_ynh"
+    },
+    "cesium": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/cesium_ynh"
+    },
+    "cheky": {
+        "branch": "master",
+        "level": 3,
+        "revision": "f93653c45dec675dca6f67cb0ffa1783c3ed8415",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/cheky_ynh"
+    },
+    "chtickynotes": {
+        "branch": "master",
+        "level": 0,
+        "revision": "94575a0db73e0ba1028882c625ebb363b0450f01",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/chtickynotes_ynh"
+    },
+    "coin": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/coin_ynh"
+    },
+    "collabora": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/collaboraonline_ynh"
+    },
+    "collaboradocker": {
+        "branch": "master",
+        "level": 3,
+        "revision": "7acf7c84572734a5c6d8d396e0f01b0acf8e5bfc",
+        "state": "working",
+        "url": "https://github.com/aymhce/collaboradocker_ynh"
+    },
+    "concrete5": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/concrete5_ynh"
+    },
+    "cops": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "7f6377bd16ffe69e07a6b64e942df2a6b3e10ea1",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/cops_ynh"
+    },
+    "couchpotato": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "2fbe760a038a1e65f574d30ffb293c7499229235",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/couchpotato_ynh"
+    },
+    "covoiturage": {
+        "branch": "master",
+        "level": 0,
+        "revision": "613412a74efebca52a8c4e213abf56443056f610",
+        "state": "working",
+        "url": "https://framagit.org/ljf/covoiturage_ynh"
+    },
+    "cowyo": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/cowyo_ynh"
+    },
+    "cryptpad": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/cryptpad_ynh"
+    },
+    "cubiks-2048": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "1e0dce523039fcbd90e775a690018529b8190f18",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/Cubiks-2048_ynh"
+    },
+    "democracyos": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/democracyos_ynh"
+    },
+    "diaspora": {
+        "branch": "master",
+        "level": 0,
+        "revision": "c6ab72967dfd015483a57714180537589aac2bf1",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/diaspora_ynh"
+    },
+    "diasporadocker": {
+        "branch": "master",
+        "level": 0,
+        "revision": "6eacf17413d795c73a9d8aeb43420749d6283e20",
+        "state": "inprogress",
+        "url": "https://github.com/aymhce/diasporadocker_ynh"
+    },
+    "discourse": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/discourse_ynh"
+    },
+    "distbin": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/distbin_ynh"
+    },
+    "docker-registry": {
+        "branch": "master",
+        "level": 3,
+        "maintained": true,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/plopoyop/docker-registry_ynh"
+    },
+    "dockercontainer": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "2ee0e6e1ea21582dd717f77a35f3b10a2b4e352e",
+        "state": "inprogress",
+        "url": "https://github.com/scith/docker_container_ynh"
+    },
+    "dockerrstudio": {
+        "branch": "master",
+        "maintained": false,
+        "revision": "4b84de21477d107111c5e65321b77881ed4fb76e",
+        "state": "inprogress",
+        "url": "https://github.com/scith/docker_rstudio_ynh"
+    },
+    "dockerui": {
+        "branch": "master",
+        "maintained": false,
+        "revision": "0c8d6674116b0da826375b5eaeab54ae1348a107",
+        "state": "inprogress",
+        "url": "https://github.com/scith/dockerui_ynh"
+    },
+    "dokuwiki": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/dokuwiki_ynh"
+    },
+    "dolibarr": {
+        "branch": "master",
+        "level": 2,
+        "revision": "14185aabdc7ac8c79844a0db206c2ab176ca03ca",
+        "state": "notworking",
+        "url": "https://github.com/Yunohost-Apps/dolibarr_ynh"
+    },
+    "domoticz": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/anubister/domoticz_ynh"
+    },
+    "dotclear2": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "e5a6b0c7ec261ca221efbeb5b5b41c8dd013775a",
+        "state": "inprogress",
+        "url": "https://github.com/rgarrigue/dotclear2_ynh"
+    },
+    "duniter": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/duniter_ynh"
+    },
+    "dynette": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/dynette_ynh"
+    },
+    "emailpoubelle": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/poubelle_ynh"
+    },
+    "emby": {
+        "branch": "master",
+        "revision": "f44c220344680ce6ccc7b57566b6247e8e6d2ce2",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/emby_ynh"
+    },
+    "ethercalc": {
+        "branch": "master",
+        "level": 0,
+        "revision": "166f55711586baf65ecf5d9404e0a1a9fbc25595",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/ethercalc_ynh"
+    },
+    "etherpad_mypads": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/etherpad_mypads_ynh"
+    },
+    "facette": {
+        "branch": "master",
+        "level": 0,
+        "revision": "799101044c4e876ceffa32c85e3d515141591f98",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/facette_ynh"
+    },
+    "fallback": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/fallback_ynh"
+    },
+    "ffsync": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/ffsync_ynh"
+    },
+    "firefly-iii": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/firefly-iii_ynh"
+    },
+    "flarum": {
+        "branch": "master",
+        "level": 7,
+        "revision": "ef96c308887151c3736928ae608825dc3946c680",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/flarum_ynh"
+    },
+    "flask": {
+        "branch": "master",
+        "level": 0,
+        "revision": "9d5cbd6ddc64b4f8a849df69b77a0259eaf204ce",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/flask_ynh"
+    },
+    "fluxbb": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "2803f37b585757fda3f66b080352d8abfada7ba5",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/fluxbb_ynh"
+    },
+    "framaestro": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "6cb4b99091da1bcc562412a2a6c8da6d02791b30",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/framaestro_ynh"
+    },
+    "framaestro_hub": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "8588e7562c232925295c2eb22a2a518b990355bb",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/framaestro_hub_ynh"
+    },
+    "framaforms": {
+        "branch": "master",
+        "level": 2,
+        "revision": "8093948529d73d5046baa75f726a77ae392e0ad4",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/framaforms_ynh"
+    },
+    "framagames": {
+        "branch": "master",
+        "level": 7,
+        "maintained": false,
+        "revision": "f3fa4bea21c19cac2534f031a14ebf19ed554062",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/framagames_ynh"
+    },
+    "freeboard": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "337111cc7e1eff33972ae7ba39db0dbcdcdd70c0",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/freeboard_ynh"
+    },
+    "freshrss": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/freshrss_ynh"
+    },
+    "friendica": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/friendica_ynh"
+    },
+    "ftp_webapp": {
+        "branch": "master",
+        "level": 0,
+        "revision": "6936f420d0d3d471af225f18cf431f4b37ade327",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/ftp_support_webapp_ynh"
+    },
+    "funkwhale": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/funkwhale_ynh"
+    },
+    "galette": {
+        "branch": "master",
+        "level": 0,
+        "revision": "9b09a7c5cca5683bcc8d89034c6a8ec024a2a441",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/galette_ynh"
+    },
+    "garradin": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/garradin_ynh"
+    },
+    "gateone": {
+        "branch": "master",
+        "level": 0,
+        "revision": "c89df3696e42dab8dff512dcc57eff786c5ff48c",
+        "state": "notworking",
+        "url": "https://github.com/Kloadut/gateone_ynh"
+    },
+    "ghost": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/ghost_ynh"
+    },
+    "gitea": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/gitea_ynh"
+    },
+    "gitlab": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/gitlab_ynh"
+    },
+    "gitlab-runner": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/kemenaran/gitlab-runner_ynh"
+    },
+    "gitolite": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "ee27e8b5dcebf59623467ea67cdaf49a73fdb3d7",
+        "state": "inprogress",
+        "url": "https://github.com/matlink/gitolite_ynh"
+    },
+    "gitrepositories": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/gitrepositories_ynh"
+    },
+    "gitweb": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "29efb4ed39fd5f168b52a5ce54950efb2df0d822",
+        "state": "inprogress",
+        "url": "https://github.com/matlink/gitweb_ynh"
+    },
+    "glowingbear": {
+        "branch": "master",
+        "level": 7,
+        "maintained": false,
+        "revision": "f8166f84eccc25faa8620c340a36a01c2fe9e6e7",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/glowing_bear_ynh"
+    },
+    "glpi": {
+        "branch": "master",
+        "level": 0,
+        "revision": "5982ac51159d42cef1c969b479346d6bc95abba5",
+        "state": "notworking",
+        "url": "https://github.com/abeudin/glpi_ynh"
+    },
+    "gnusocial": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "523263efaa94b347f2ea27935f67d265e15f4d21",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/gnusocial_ynh"
+    },
+    "gogs": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/gogs_ynh"
+    },
+    "gotify": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/gotify_ynh"
+    },
+    "grafana": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/grafana_ynh"
+    },
+    "grav": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/grav_ynh"
+    },
+    "h5ai": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/h5ai_ynh"
+    },
+    "halcyon": {
+        "branch": "master",
+        "level": 6,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/halcyon_ynh"
+    },
+    "haste": {
+        "branch": "master",
+        "level": 0,
+        "revision": "e7439b9cc48f170621ad3e8ceddbba29e0a36012",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/haste_ynh"
+    },
+    "headphones": {
+        "branch": "master",
+        "level": 1,
+        "revision": "8f2a891a987dff486d190032cef4352e7f3d8796",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/headphones_ynh"
+    },
+    "hextris": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/hextris_ynh"
+    },
+    "homeassistant": {
+        "branch": "master",
+        "level": 7,
+        "revision": "017e21b1d5700bf64a428ec428257bfcde31b02b",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/homeassistant_ynh"
+    },
+    "horde": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/horde_ynh"
+    },
+    "hotspot": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/labriqueinternet/hotspot_ynh"
+    },
+    "htmltool": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "f18ed28892f1eb15ef39a9cd9de9c43612f15d2d",
+        "state": "working",
+        "url": "https://github.com/isserterrus/htmltools_ynh"
+    },
+    "htpc-manager": {
+        "branch": "master",
+        "level": 2,
+        "revision": "8167ef9705e3e063278501f5cc2f6b1169241352",
+        "state": "inprogress",
+        "url": "https://github.com/scith/htpc-manager_ynh"
+    },
+    "hubzilla": {
+        "branch": "master",
+        "level": 4,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/hubzilla_ynh"
+    },
+    "huginn": {
+        "branch": "master",
+        "level": 0,
+        "revision": "8729f3aee37d16c4bec7737aa616f1198ec34f78",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/huginn_ynh"
+    },
+    "humhub": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "ac38c7ecbff67de9d5785b1d75aa6c797d663110",
+        "state": "inprogress",
+        "url": "https://github.com/yunohost-apps/humhub_ynh"
+    },
+    "ihatemoney": {
+        "branch": "master",
+        "level": 1,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/ihatemoney_ynh"
+    },
+    "jappix": {
+        "branch": "master",
+        "level": 7,
+        "revision": "611170f1575603e65225b4b353f61884c7b0b42e",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/jappix_ynh"
+    },
+    "jappix_mini": {
+        "branch": "master",
+        "level": 0,
+        "revision": "230e99a3a35e165e095ea944acaa7bc5d34acb7c",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/jappix_mini_ynh"
+    },
+    "jeedom": {
+        "branch": "master",
+        "level": 1,
+        "maintained": false,
+        "revision": "d23e0b30b630740ec66fa83c6505c5afb51698e1",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/jeedom_ynh"
+    },
+    "jenkins": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/jenkins_ynh"
+    },
+    "jirafeau": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/jirafeau_ynh"
+    },
+    "jitsi": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "fe908a76640e373042d80e23fa0bc618453a3826",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/jitsi_ynh"
+    },
+    "joomla": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/joomla_ynh"
+    },
+    "jupyterlab": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/jupyterlab_ynh"
+    },
+    "kanboard": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/kanboard_ynh"
+    },
+    "keeweb": {
+        "branch": "master",
+        "level": 7,
+        "maintained": false,
+        "revision": "9e5c65c461a22d9b85be732e072ff938911106ad",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/keeweb_ynh"
+    },
+    "kimai2": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/kimai2_ynh"
+    },
+    "kiwiirc": {
+        "branch": "master",
+        "level": 0,
+        "revision": "c0aba5c4e2232d837299fe0cba12a962dd0f3bfa",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/kiwiirc_ynh"
+    },
+    "kodi": {
+        "branch": "master",
+        "level": 0,
+        "revision": "28f535a38623457643aac61ffbf0d29c84d0fc66",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/kodi_ynh"
+    },
+    "kresus": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/kresus_ynh"
+    },
+    "laverna": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "0ede9aebe821d579a9bf10621cfd438d30a63043",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/laverna_ynh"
+    },
+    "lbcalerte": {
+        "branch": "master",
+        "level": 0,
+        "revision": "a38a83fea289f77910fd98b34ea58eea5f5909db",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/LBCAlerte_ynh"
+    },
+    "leed": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/leed_ynh"
+    },
+    "lektor": {
+        "branch": "master",
+        "level": 3,
+        "revision": "80e1d6681ec4f5764cfa6ab8e90538eee763784a",
+        "state": "notworking",
+        "url": "https://github.com/Yunohost-Apps/lektor_ynh"
+    },
+    "libreerp": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/Yunohost-Apps/libreerp_ynh"
+    },
+    "libresonic": {
+        "branch": "master",
+        "level": 1,
+        "revision": "d63eeb9fbfab3eb4b925c3df233d0e5a202ed446",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/libresonic_ynh"
+    },
+    "libreto": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/libreto_ynh"
+    },
+    "limesurvey": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/limesurvey_ynh"
+    },
+    "linuxdash": {
+        "branch": "master",
+        "level": 0,
+        "revision": "f6c037bed44c5f1a5d5cff3fc64b733681ef7244",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/linuxdash_ynh"
+    },
+    "lstu": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/lstu_ynh"
+    },
+    "lufi": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/lufi_ynh"
+    },
+    "lutim": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/lutim_ynh"
+    },
+    "lychee": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "30af5c94460a44401dd40553ec0d77b6e6087e69",
+        "state": "inprogress",
+        "url": "https://github.com/titoko/lychee_ynh"
+    },
+    "mailman": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/yunohost-apps/mailman_ynh"
+    },
+    "mastodon": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/mastodon_ynh"
+    },
+    "matomo": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/matomo_ynh"
+    },
+    "mattermost": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/mattermost_ynh"
+    },
+    "mediadrop": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "a9034b635e0f0f3d2a4380f54fb19f79cd8e8f4d",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/mediadrop_ynh"
+    },
+    "mediagoblin": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "e516845becf6fa640b2dd7de5b9cb36e89be0ae1",
+        "state": "inprogress",
+        "url": "https://github.com/jeromelebleu/mediagoblin_ynh"
+    },
+    "mediawiki": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/mediawiki_ynh"
+    },
+    "medusa": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/guigot/medusa_ynh"
+    },
+    "menu": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/menu_ynh"
+    },
+    "minchat": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "b77ccdcfba70d7279cc01d3c7847144338ee8a23",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/minchat_ynh"
+    },
+    "minetest": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "0b447d2c7e0c0d60c93f4d04f9018025a23c67eb",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/minetest_ynh"
+    },
+    "minidlna": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/minidlna_ynh"
+    },
+    "miniflux": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "05e14da8617c73715efa39dcdd4965f0e1bba893",
+        "state": "inprogress",
+        "url": "https://github.com/mat-mo/miniflux_ynh"
+    },
+    "modernpaste": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "d5715d86bff4b126baea05820127bf2d29ed4c71",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/modernpaste_ynh"
+    },
+    "monica": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/monica_ynh"
+    },
+    "monit": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "79c43fc8fb2e4ebb9950f2bbfc74fc96d6b41490",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/monit_ynh"
+    },
+    "monitorix": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/monitorix_ynh"
+    },
+    "moodle": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/moodle_ynh"
+    },
+    "mopidy": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "b001c8d64d62ceafa5d60627b64761a35757b998",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/mopidy_ynh"
+    },
+    "movim": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "ef940a1dd1c4b21e42c62f74b244f585980b3050",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/movim_ynh"
+    },
+    "multi_webapp": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/multi_webapp_ynh"
+    },
+    "mumble_admin_plugin": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "c525792adcb6f4b8b2f94aab4b1a3e8a0b19eb78",
+        "state": "inprogress",
+        "url": "https://github.com/matlink/mumble_admin_plugin_ynh"
+    },
+    "mumbleserver": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/mumbleserver_ynh"
+    },
+    "munin": {
+        "branch": "master",
+        "level": 3,
+        "revision": "b45d6d12af7fea8c6183f3c80003416cd36fec1a",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/munin_ynh"
+    },
+    "my-mind": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/my-mind_ynh"
+    },
+    "my_webapp": {
+        "branch": "master",
+        "level": 1,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/my_webapp_ynh"
+    },
+    "mycryptochat": {
+        "branch": "master",
+        "level": 0,
+        "revision": "94868a77cc584f789e358b250e483b083181478c",
+        "state": "notworking",
+        "url": "https://github.com/mrtino/mycryptochat_ynh"
+    },
+    "mytinytodo": {
+        "branch": "master",
+        "level": 7,
+        "revision": "ef789bd2ef5c1ce53def998c88a6f396c4b11e85",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/mytinytodo_ynh"
+    },
+    "netdata": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/netdata_ynh"
+    },
+    "nextcloud": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/nextcloud_ynh"
+    },
+    "nexusoss": {
+        "branch": "master",
+        "level": 0,
+        "revision": "7b54ee3195c0dc87e1032ba5c94b21f30d84e72c",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/nexusoss_ynh"
+    },
+    "noalyss": {
+        "branch": "master",
+        "level": 1,
+        "revision": "cccbaa4e48c3aa44cd5742aed5301fe9a46179b9",
+        "state": "inprogress",
+        "url": "https://github.com/Yunohost-Apps/noalyss_ynh"
+    },
+    "nodebb": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/nodebb_ynh"
+    },
+    "ofbiz": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "9ca8db3694b76aa9068ac4ba327c13151f8c5356",
+        "state": "inprogress",
+        "url": "https://github.com/nomakaFr/ofbiz_ynh"
+    },
+    "onlyoffice": {
+        "branch": "master",
+        "revision": "9eee4dcb9f7602247981b4ba2a7ca7ab12634c26",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/onlyoffice_ynh"
+    },
+    "openidsimplesamlphp": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "f992c392a31e37421b339b8a6cfb736e0d5097a8",
+        "state": "inprogress",
+        "url": "https://github.com/julienmalik/openid-simplesamlphp_ynh"
+    },
+    "opennote": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "a0543195db635a93c864066114b7edd1887a1d87",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/OpenNote_ynh"
+    },
+    "opensondage": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/opensondage_ynh"
+    },
+    "openvpn": {
+        "branch": "master",
+        "level": 3,
+        "revision": "ccb123ec51373b5967079ff868bbe2e0327ee25c",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/openvpn_ynh"
+    },
+    "ore": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/ore_ynh"
+    },
+    "osada": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/osada_ynh"
+    },
+    "osjs": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/osjs_ynh"
+    },
+    "osmw": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "e26d5f5b8e075ec9cd0c320445e5ea2e2bd9fd29",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/osmw_ynh"
+    },
+    "owncloud": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "dd78f3575b025b78bae116cc094db4d8b6fef2e2",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-apps/owncloud_ynh"
+    },
+    "owntracks": {
+        "branch": "master",
+        "level": 7,
+        "revision": "25280e9d9aa54109f8f8654984f85c72ff0c80db",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/owntracks_ynh"
+    },
+    "pagure": {
+        "branch": "master",
+        "level": 0,
+        "revision": "a24e32d59a1cc1b4482b4d57367de671c463912f",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/pagure_ynh"
+    },
+    "peertube": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/peertube_ynh"
+    },
+    "pelican": {
+        "branch": "master",
+        "level": 0,
+        "revision": "a2f37b8e277ba173b53f73320514f1fc7f3aa3ac",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/pelican_ynh"
+    },
+    "pgadmin": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/pgadmin_ynh"
+    },
+    "phpBB": {
+        "branch": "master",
+        "level": 1,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-apps/phpbb_ynh"
+    },
+    "phpldapadmin": {
+        "branch": "master",
+        "level": 3,
+        "revision": "785706fb2607e95fbc4876e1367a715a6b8543d2",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/phpldapadmin_ynh"
+    },
+    "phpmyadmin": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/phpmyadmin_ynh"
+    },
+    "phpsysinfo": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "1df61e1d8b2836c2b44e7bd69c32ce6f00baf072",
+        "state": "working",
+        "url": "https://github.com/inrepublica/phpsysinfo_ynh"
+    },
+    "pihole": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/pihole_ynh"
+    },
+    "pilea": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/pilea_ynh"
+    },
+    "piratebox": {
+        "branch": "master",
+        "level": 1,
+        "maintained": false,
+        "revision": "19029e995498660035302adf0ce337cc5296bd7b",
+        "state": "working",
+        "url": "https://github.com/labriqueinternet/piratebox_ynh"
+    },
+    "piwigo": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/piwigo_ynh"
+    },
+    "pixelfed": {
+        "branch": "master",
+        "level": 2,
+        "revision": "4cd7ca2e6bb3c18fdeaeab75b3aabc1d4587877b",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/pixelfed_ynh"
+    },
+    "pleroma": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/pleroma_ynh"
+    },
+    "plexmediaserver": {
+        "branch": "master",
+        "level": 1,
+        "revision": "ed611f0ab9eafb1b32263b413ced9fbbd4fd7b45",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/plexmediaserver_ynh"
+    },
+    "plonecms": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/plonecms_ynh"
+    },
+    "plume": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/plume_ynh"
+    },
+    "pluxml": {
+        "branch": "master",
+        "level": 0,
+        "revision": "fdc4d361e94e839e58e053a985a2e1a2e1a7c6a5",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/pluxml_ynh"
+    },
+    "portainer": {
+        "branch": "master",
+        "level": 3,
+        "revision": "be44adf760ad84f2bad06e1f6380f0025f58cbdb",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/portainer_ynh"
+    },
+    "prestashop": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/prestashop_ynh"
+    },
+    "prettynoemiecms": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/prettynoemiecms_ynh"
+    },
+    "proftpd": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "574d06e0ace72ffa11f3a736fd8821de773583c7",
+        "state": "inprogress",
+        "url": "https://github.com/abeudin/proftpd_ynh"
+    },
+    "pydio": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "2600c6f10f75d0a1f834f0ae73afd5deef42d323",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/pydio_ynh"
+    },
+    "radicale": {
+        "branch": "master",
+        "level": 2,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/radicale_ynh"
+    },
+    "rainloop": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/rainloop_ynh"
+    },
+    "redirect": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "2230d41e8b788fa35fe3bf0769b71ab24a002e95",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/redirect_ynh"
+    },
+    "remotestorage": {
+        "branch": "master",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/RemoteStorage_ynh"
+    },
+    "riot": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/riot_ynh"
+    },
+    "roadiz": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "3b9a44709b298869dc3be8bdd0aae43fdd7c2b24",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/roadiz_ynh"
+    },
+    "rocketchat": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/rocketchat_ynh"
+    },
+    "roundcube": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/roundcube_ynh"
+    },
+    "rss-bridge": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/rss-bridge_ynh"
+    },
+    "rutorrent": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "34ba187c2e76dc6adf77de41304647f6569c6dd8",
+        "state": "inprogress",
+        "url": "https://github.com/CotzaDev/rutorrent_ynh"
+    },
+    "scm": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "5026ef8bc61a7b1533fca78ce7e4dc2bbb14c5ad",
+        "state": "inprogress",
+        "url": "https://github.com/drfred1981/scm-manager_ynh"
+    },
+    "scrumblr": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/scrumblr_ynh"
+    },
+    "seafile": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/seafile_ynh"
+    },
+    "searx": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/searx_ynh"
+    },
+    "seenthis": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "b77a7c9cf0ea72018cf3ca396af0fa8ba9a68405",
+        "state": "inprogress",
+        "url": "https://github.com/magikcypress/seenthis_ynh"
+    },
+    "shaarli": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/shaarli_ynh"
+    },
+    "shellinabox": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/shellinabox_ynh"
+    },
+    "shsd": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/shsd_ynh"
+    },
+    "shuri": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/shuri_ynh"
+    },
+    "sickbeard": {
+        "branch": "master",
+        "level": 1,
+        "revision": "c88fd173e9e632df5de1c7acac57c503d317addb",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/sickbeard_ynh"
+    },
+    "sickrage": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "b3a136938ad02d98051fe2cda40a9a2a3d10c763",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/sickrage_ynh"
+    },
+    "simpad": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/simpad_ynh"
+    },
+    "sogo": {
+        "branch": "master",
+        "level": 7,
+        "maintained": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/sogo_ynh"
+    },
+    "sonerezh": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "487fcbbea0408fed899ddb4346b3278586f2ea30",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/sonerezh_ynh"
+    },
+    "spftoolbox": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/spftoolbox_ynh"
+    },
+    "spip": {
+        "branch": "master",
+        "level": 4,
+        "revision": "2016c3a3a972dc74d1ae1ec74ff80987eb753ce9",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/spip_ynh"
+    },
+    "spip2": {
+        "branch": "master",
+        "level": 7,
+        "maintained": false,
+        "revision": "58b27c9c220cc1d3e1759889e4588728bcc8a130",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/spip2_ynh"
+    },
+    "squid3": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/squid3_ynh"
+    },
+    "ssh_chroot_dir": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/ssh_chroot_dir_ynh"
+    },
+    "staticwebapp": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "61eb7e0c560d91c74985fef37e7dca402c67ad18",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/staticwebapp_ynh"
+    },
+    "strut": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/strut_ynh"
+    },
+    "subsonic": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "b78fb72bcc0137e91d2166d8f3bf7d13d7920ca9",
+        "state": "inprogress",
+        "url": "https://github.com/drfred1981/subsonic_ynh"
+    },
+    "svgedit": {
+        "branch": "master",
+        "level": 3,
+        "maintained": false,
+        "revision": "6f3a05b03d60142ad19ee8815f7b5d68adc888a4",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/svgedit_ynh"
+    },
+    "synapse": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/synapse_ynh"
+    },
+    "sympa": {
+        "branch": "master",
+        "level": 0,
+        "revision": "9128bfa577781b0391925ef43eb99d8e01e40ef5",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/sympa_ynh"
+    },
+    "syncthing": {
+        "branch": "master",
+        "level": 3,
+        "revision": "0d843dd0604a505ef9a02c1d5572c9a5ae810bcf",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/syncthing_ynh"
+    },
+    "tagspaces": {
+        "branch": "master",
+        "level": 2,
+        "maintained": false,
+        "revision": "22afa970550cf5f1d8c21c6a1fa52fa611ae918f",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/tagspaces_ynh"
+    },
+    "teampass": {
+        "branch": "master",
+        "level": 2,
+        "revision": "64fef4eb687dbf08a13563c025d765892750ce56",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/teampass_ynh"
+    },
+    "telegram_chatbot": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "fb4e8aeb0e4f34e17e7450084e4827eabfd4ce04",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/telegram_chatbot_ynh"
+    },
+    "thelounge": {
+        "branch": "master",
+        "level": 4,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/thelounge_ynh"
+    },
+    "timeoff": {
+        "branch": "master",
+        "level": 2,
+        "revision": "25925abef093ac18f077326c3e7cb0dec9e0cb9b",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/timeoff_ynh"
+    },
+    "torclient": {
+        "branch": "master",
+        "level": 1,
+        "maintained": false,
+        "revision": "f0707d9f926a77b8cab8ee4eb2b295e6144d959a",
+        "state": "working",
+        "url": "https://github.com/labriqueinternet/torclient_ynh"
+    },
+    "torrelay": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "0a35298b460413c70f2e95933431eb80afaa125e",
+        "state": "inprogress",
+        "url": "https://github.com/matlink/torrelay_ynh"
+    },
+    "transmission": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/transmission_ynh"
+    },
+    "transwhat": {
+        "branch": "master",
+        "level": 0,
+        "revision": "abf1455c197cfd56531dfc0141bf7f249e282673",
+        "state": "notworking",
+        "url": "https://github.com/Josue-T/transwhat_ynh"
+    },
+    "turtl": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "815abd8720e82da346c4891515bf08fb3701b982",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/turtl_ynh"
+    },
+    "ttrss": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/ttrss_ynh"
+    },
+    "tyto": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/tyto_ynh"
+    },
+    "ulogger": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/ulogger_ynh"
+    },
+    "umap": {
+        "branch": "master",
+        "level": 0,
+        "revision": "e569c56e76f79da3580bd3432406dd56225e814d",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/umap_ynh"
+    },
+    "unattended_upgrades": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/unattended_upgrades_ynh"
+    },
+    "vpnclient": {
+        "branch": "master",
+        "level": 5,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/labriqueinternet/vpnclient_ynh"
+    },
+    "wallabag2": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
+    },
+    "webapp_multi_inst": {
+        "branch": "master",
+        "level": 1,
+        "maintained": false,
+        "revision": "f86a66945f73a62c12e9041d5d3a9d268eb362f6",
+        "state": "working",
+        "url": "https://github.com/polytan02/webapp_multi_ynh"
+    },
+    "weblate": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/weblate_ynh"
+    },
+    "webmin": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/webmin_ynh"
+    },
+    "webogram": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "1d7a5378279743e1acc88978777e0b7d76113bfa",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/webogram_ynh"
+    },
+    "webtrees": {
+        "branch": "master",
+        "level": 0,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/webtrees_ynh"
+    },
+    "wekan": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/wekan_ynh"
+    },
+    "wemawema": {
+        "branch": "master",
+        "level": 7,
+        "revision": "b8b659f53e5617273c06fc4ea119339d40d12b2d",
+        "state": "working",
+        "url": "https://github.com/Yunohost-apps/wemawema_ynh"
+    },
+    "wifiwithme": {
+        "branch": "master",
+        "level": 0,
+        "revision": "14e01a3981bde7192e100b1f9cfa50e95d6cb89b",
+        "state": "notworking",
+        "url": "https://code.ffdn.org/ljf/wifiwithme_ynh"
+    },
+    "wikijs": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/wikijs_ynh"
+    },
+    "wildfly": {
+        "branch": "master",
+        "level": 1,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/wildfly_ynh"
+    },
+    "wordpress": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/wordpress_ynh"
+    },
+    "writefreely": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/writefreely_ynh"
+    },
+    "yacy": {
+        "branch": "master",
+        "level": 0,
+        "revision": "e64c715d014b1b1c0ba573164a85a2ebc29d48a6",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/yacy_ynh"
+    },
+    "yellowcms": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "bb46bdb815110052c928b7f66e8645e156da585c",
+        "state": "inprogress",
+        "url": "https://github.com/YunoHost-Apps/yellowcms_ynh"
+    },
+    "yourls": {
+        "branch": "master",
+        "level": 3,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/yourls_ynh"
+    },
+    "youtube-dl-webui": {
+        "branch": "master",
+        "maintained": false,
+        "revision": "c4ad37ea15ef00a4b1bddd8d9c38d4ecc53b301c",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/youtube-dl-webui_ynh"
+    },
+    "yunofav": {
+        "branch": "master",
+        "level": 0,
+        "revision": "14e85b0e0ead5c34e69f8faa97b2ec10aa3cc68b",
+        "state": "notworking",
+        "url": "https://github.com/YunoHost-Apps/yunofav_ynh"
+    },
+    "yunohost": {
+        "branch": "master",
+        "level": 0,
+        "revision": "795449cb43ccdba949c814746d6ea90eee0a7259",
+        "state": "working",
+        "url": "https://github.com/aymhce/yunohost_ynh"
+    },
+    "z-push": {
+        "branch": "master",
+        "level": 6,
+        "maintained": false,
+        "revision": "4ae47475afc9cc85670a3b0bc17d80a869bc5b90",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/z-push_ynh"
+    },
+    "zabbix": {
+        "branch": "master",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/zabbix_ynh"
+    },
+    "zerobin": {
+        "branch": "master",
+        "level": 7,
+        "high_quality": true,
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-apps/zerobin_ynh"
+    },
+    "zeronet": {
+        "branch": "master",
+        "level": 2,
+        "revision": "1a77591a8dffdc4bcfd297a9340e98e0e6775865",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/zeronet_ynh"
+    },
+    "zomburl": {
+        "branch": "master",
+        "level": 0,
+        "maintained": false,
+        "revision": "f8a07838abba2f275348fb44b52039016d7c02e8",
+        "state": "inprogress",
+        "url": "https://github.com/courgette/zomburl_ynh"
+    }
+}

--- a/change_level.py
+++ b/change_level.py
@@ -7,7 +7,7 @@ import json
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) < 3:
-        print "Usage: ./change_level.py <official.json|community.json> <app_id> <level>"
+        print "Usage: ./change_level.py <official.json|community.json|apps.json> <app_id> <level>"
         sys.exit(1)
 
     app_list_name, app_id, level = sys.argv[1:4]

--- a/should_i_rebuild.sh
+++ b/should_i_rebuild.sh
@@ -17,9 +17,10 @@ if [ "$before_pull_commit" != "$(git show HEAD | head -n 1)" ]
 then
     python ./list_builder.py -g $1 official.json
     python ./list_builder.py -g $1 community.json
+    python ./list_builder.py -g $1 apps.json
     python ./list_builder.py -g $1 dev.json
 
-    python ./update_translations.py official-build.json community-build.json dev-build.json
+    python ./update_translations.py official-build.json community-build.json apps-build.json dev-build.json
 
     for i in official community dev
     do


### PR DESCRIPTION
Following https://github.com/YunoHost/apps/pull/677

This PR propose to merge Official and Community into one list simply named "Apps"
Official apps are tagged as `working` instead of `validated` and get by the way the flag `high_quality`. Because there were Official apps so far.

**This PR should be merged after https://github.com/YunoHost/yunohost-admin/pull/225**