### PR TITLE
Add new PluXml

### DIFF
--- a/community.json
+++ b/community.json
@@ -1277,9 +1277,9 @@
     },
     "pluxml": {
         "branch": "master",
-        "revision": "b2291e9defc521cb25a6ad14a810b9fdf49642ee",
+        "revision": "HEAD",
         "state": "inprogress",
-        "url": "https://framagit.org/toitoinebzh/pluxml_ynh"
+        "url": "https://github.com/YunoHost-Apps/pluxml_ynh"
     },
     "portainer": {
         "branch": "master",

--- a/community.json
+++ b/community.json
@@ -1277,7 +1277,6 @@
     },
     "pluxml": {
         "branch": "master",
-        "level": 3,
         "revision": "b2291e9defc521cb25a6ad14a810b9fdf49642ee",
         "state": "inprogress",
         "url": "https://framagit.org/toitoinebzh/pluxml_ynh"

--- a/community.json
+++ b/community.json
@@ -1277,10 +1277,10 @@
     },
     "pluxml": {
         "branch": "master",
-        "level": 0,
-        "revision": "fdc4d361e94e839e58e053a985a2e1a2e1a7c6a5",
-        "state": "notworking",
-        "url": "https://github.com/YunoHost-Apps/pluxml_ynh"
+        "level": 3,
+        "revision": "b2291e9defc521cb25a6ad14a810b9fdf49642ee",
+        "state": "inprogress",
+        "url": "https://framagit.org/toitoinebzh/pluxml_ynh"
     },
     "portainer": {
         "branch": "master",


### PR DESCRIPTION
The older pluxml_ynh seems to be unmaintained.

I propose this new script. It works with the last version of Pluxml (5.7). I have been able to install/upgrade/remove it. Package_check reports success to all check.
I set Level4 to na in check_process because PluXml does not support ldap/ssowat authentification.

I choose to set the state as "in progress", because I would like to have more feedback about this script.

This is the first time I make an application for yunohost, I would be happy if you can check that everything is ok.

```
Package linter:                  SUCCESS
Installation:                    SUCCESS
Deleting:                        SUCCESS
Installation in a sub path:      SUCCESS
Deleting from a sub path:        SUCCESS
Installation on the root:        SUCCESS
Deleting from root:              SUCCESS
Upgrade:                         SUCCESS
Installation in private mode:    SUCCESS
Installation in public mode:     SUCCESS
Multi-instance installations:    SUCCESS
Malformed path:                  SUCCESS
Port already used:               SUCCESS
Backup:                          SUCCESS
Restore:                         SUCCESS
Change URL:                      SUCCESS
grep: /home/admin/package_check/levels.json: Aucun fichier ou dossier de ce type
Level of this application: 3 ()
	   Level 1: 1
	   Level 2: 1
	   Level 3: 1
	   Level 4: 0
	   Level 5: 1
	   Level 6: 1
	   Level 7: 1
	   Level 8: 0
	   Level 9: 0
	   Level 10: 0
You can find the complete log of these tests in /home/admin/package_check/Complete.log
Global working time for all tests: 21 minutes, 13 seconds.
Disable iptables rules.
Disable the network bridge.
admin@domain:~$ 
```