### PR TITLE
[fix] .git should be avoided, makes stuff more difficult to parse ;P

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ App example addition:
     "wallabag": {
         "branch": "master",
         "revision": "c2fc62438ac5c9503e3f4ebfdc425ec03a0ec0c0",
-        "url": "https://github.com/abeudin/wallabag_ynh.git",
+        "url": "https://github.com/abeudin/wallabag_ynh",
         "state": "working"
     }
 ```


### PR DESCRIPTION
It seems it's better for parsing to don't write the url with .git