### PR TITLE
set mediawiki, pluxml state as working

### DIFF
--- a/community.json
+++ b/community.json
@@ -906,9 +906,8 @@
     "mediawiki": {
         "branch": "master",
         "level": 0,
-        "maintained": false,
         "revision": "HEAD",
-        "state": "inprogress",
+        "state": "working",
         "url": "https://github.com/YunoHost-Apps/mediawiki_ynh"
     },
     "medusa": {
@@ -1278,7 +1277,7 @@
     "pluxml": {
         "branch": "master",
         "revision": "HEAD",
-        "state": "inprogress",
+        "state": "working",
         "url": "https://github.com/YunoHost-Apps/pluxml_ynh"
     },
     "portainer": {


### PR DESCRIPTION
Since the last pull request (https://github.com/YunoHost-Apps/pluxml_ynh/pull/28) on pluxml_ynh, pluxml is now working.

Once this pull request will be merge (https://github.com/YunoHost-Apps/mediawiki_ynh/pull/2), mediawiki should also be working.