### PR TITLE
Remove spip2, upstream unmaintained, people should move to spip 3...

### DIFF
--- a/community.json
+++ b/community.json
@@ -1479,14 +1479,6 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/spip_ynh"
     },
-    "spip2": {
-        "branch": "master",
-        "level": 7,
-        "maintained": false,
-        "revision": "58b27c9c220cc1d3e1759889e4588728bcc8a130",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/spip2_ynh"
-    },
     "squid3": {
         "branch": "master",
         "level": 0,


### PR DESCRIPTION
Follow-up of https://github.com/YunoHost/doc/pull/943

- SPIP 2 upstream ain't maintained anymore
- The yunohost app neither
- There might be security risks involved in using SPIP2 ...

To be discussed