### PR TITLE
Request for high_quality tag

### DIFF
--- a/community.json
+++ b/community.json
@@ -778,6 +778,7 @@
     },
     "leed": {
         "branch": "master",
+        "high_quality": true,
         "level": 7,
         "revision": "HEAD",
         "state": "working",


### PR DESCRIPTION
I just updated Leed to be up to date with the example app.
So, I make a request for the high_quality tag.

---
Mandatory check boxes:
- [x] The package is level 7.
- [x] The package has been level 7 for at least 1 month.
- [x] The package has been in the list for at least 2 months.
- [x] The package is up to date regarding the packaging recommendations and helpers.
- [x] The repository has a testing branch.
- [x] All commits are made in testing branch before being merged into master.
- [x] The list points to HEAD, not to a specific commit.
- [x] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md)
- [x] The package shows the YunoHost tile `yunohost_panel.conf.inc`

Optional check boxes:
- [x] The package is level 7 for ARM as well.
*If the app is really important for the community, we can accept it with a broken ARM support. But this should be clearly explained and managed.*
- [x] The app is up to date with the upstream version.  
*If this is possible with the last YunoHost version.*
- [ ] The package supports LDAP  
*If the app upstream supports it*
- [ ] The package supports HTTP authentication  
*If the app upstream supports it*