### PR TITLE
Cheky app - Use HEAD instead of commid id

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -217,7 +217,7 @@
     "cheky": {
         "branch": "master",
         "level": 7,
-        "revision": "f93653c45dec675dca6f67cb0ffa1783c3ed8415",
+        "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/cheky_ynh"
     },


### PR DESCRIPTION
I totally forgot about modifying this list and Cheky_ynh uses a testing branch. So point to "HEAD" instead