### PR TITLE
Removing libresonic

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -942,13 +942,6 @@
         "state": "working",
         "url": "https://github.com/Yunohost-Apps/libreerp_ynh"
     },
-    "libresonic": {
-        "branch": "master",
-        "level": 0,
-        "revision": "d63eeb9fbfab3eb4b925c3df233d0e5a202ed446",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/libresonic_ynh"
-    },
     "libreto": {
         "branch": "master",
         "level": 7,


### PR DESCRIPTION
* upstream app has been forked as airsonic: https://airsonic.github.io/
* upstream app hasn't been updated since two years
* [airsonic_ynh](https://github.com/YunoHost-Apps/airsonic_ynh) is now level 7 thanks to @kay0u