### PR TITLE
Remove unmaintained apps which are a ~redundant with my_webapp

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1743,14 +1743,6 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/ssh_chroot_dir_ynh"
     },
-    "staticwebapp": {
-        "branch": "master",
-        "level": 0,
-        "maintained": false,
-        "revision": "61eb7e0c560d91c74985fef37e7dca402c67ad18",
-        "state": "notworking",
-        "url": "https://github.com/YunoHost-Apps/staticwebapp_ynh"
-    },
     "streama": {
         "branch": "master",
         "level": 0,
@@ -1947,14 +1939,6 @@
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/wallabag2_ynh"
-    },
-    "webapp_multi_inst": {
-        "branch": "master",
-        "level": 1,
-        "maintained": false,
-        "revision": "f86a66945f73a62c12e9041d5d3a9d268eb362f6",
-        "state": "working",
-        "url": "https://github.com/polytan02/webapp_multi_ynh"
     },
     "weblate": {
         "branch": "master",


### PR DESCRIPTION
While inspecting the list of apps yesterday, found out about these two apps which really sounds like a duplicate work of the custom webapp things (my_webapp and multi_webapp) ... So proposing to remove them from the list because that's just confusing and redundant

(Also I wish I would understand if there's really a need behind the my_webapp and multi_webapp - can't we add FTP support in multi_webapp as well ?)