### PR TITLE
Rename openvpn to vpnserver

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1304,12 +1304,12 @@
         "state": "working",
         "url": "https://github.com/YunoHost-apps/opensondage_ynh"
     },
-    "openvpn": {
+    "vpnserver": {
         "branch": "master",
         "level": 3,
         "revision": "ccb123ec51373b5967079ff868bbe2e0327ee25c",
         "state": "notworking",
-        "url": "https://github.com/YunoHost-Apps/openvpn_ynh"
+        "url": "https://github.com/YunoHost-Apps/vpnserver_ynh"
     },
     "osada": {
         "branch": "master",


### PR DESCRIPTION
Because it's been like 6 months I'm mumbling about this so I finally took the dictatorial decision to rename it because I'm so mad about the ambiguity of the name (vpnclient is also based on openvpn so)