### PR TITLE
Remove dev.json ...

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,9 +1,0 @@
-{
-    "testupgrade_ynh": {
-        "branch": "master",
-        "level": 0,
-        "revision": "97e3443f47b20161ca6b284e1ef7a9a65838ac42",
-        "state": "inprogress",
-        "url": "https://github.com/YunoHost-apps/testupgrade_ynh"
-    }
-}


### PR DESCRIPTION
Do we really need this ? In the end we have https://github.com/YunoHost/test_apps meant for tests ... 

Not that it's really important, but we have a cron job building this list and it miserably crashes from time to time which creates big error messages in mailboxes ...