### PR TITLE
Adding OpenProject in the app list

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1324,6 +1324,14 @@
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/OpenNote_ynh"
     },
+    "openproject": {
+        "branch": "master",
+        "level": 0,
+        "maintained": true,
+        "revision": "HEAD",
+        "state": "inprogress",
+        "url": "https://github.com/moutonjr/openproject_ynh"
+    },
     "opensondage": {
         "branch": "master",
         "high_quality": true,


### PR DESCRIPTION
OpenProject is still ongoing, the bash code should be neat.

See https://forum.yunohost.org/t/app-integration-of-openproject/9141/2 for details
and https://www.openproject.org/ for the software.