### PR TITLE
Tvheadend app package

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1953,6 +1953,12 @@
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/turtl_ynh"
     },
+    "tvheadend": {
+        "branch": "master",
+        "revision": "HEAD",
+        "url": "https://github.com/SylvainCecchetto/tvheadend_ynh",
+        "state": "working"
+    },
     "tyto": {
         "branch": "master",
         "level": 7,


### PR DESCRIPTION
Hi,

This a the package of the Tvheadend app (https://tvheadend.org), a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT>IP and HDHomeRun as input sources.

Package_checker gave me a level of 7 on my local server.
