### PR TITLE
Ste menu as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1541,7 +1541,7 @@
         "category": "wat",
         "level": 7,
         "revision": "HEAD",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/menu_ynh"
     },
     "minchat": {


### PR DESCRIPTION
This app could break new yunohost version due to the moulinette module mechanism only used by this app.