### PR TITLE
DokuWiki is maintained

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -557,6 +557,7 @@
     "dokuwiki": {
         "branch": "master",
         "category": "publishing",
+        "maintained": true,
         "high_quality": true,
         "level": 8,
         "revision": "HEAD",


### PR DESCRIPTION
# Validation template for High Quality tag request

This template is designed to be used as it is by Apps group to validate requests from packagers for the tag High Quality.

Mandatory check boxes:
- [x] The package is level 7. (Maniack C)
- [x] The package has been level 7 for at least 1 month. (Maniack C)
- [x] The package has been in the list for at least 2 months. (Maniack C)
- [x] The package is up to date regarding the packaging recommendations and helpers. (Maniack C)
- [x] The repository has a testing branch. (Maniack C)
- [x] All commits are made in testing branch before being merged into master. (Maniack C)
- [x] The list points to HEAD, not to a specific commit. (Maniack C)
- [ ] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md)
- [x] The package shows the YunoHost tile `yunohost_panel.conf.inc` (Maniack C)

Optional check boxes:
- [x] The package is level 7 for ARM as well. (Maniack C)
*If the app is really important for the community, we can accept it with a broken ARM support. But this should be clearly explained and managed.*
- [ ] The app is up to date with the upstream version.  
*If this is possible with the last YunoHost version.*
- [x] The package supports LDAP   (Maniack C)
*If the app upstream supports it*
- [x] The package supports HTTP authentication   (Maniack C)
*If the app upstream supports it*
