### PR TITLE
new lionwiki-t2t location

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1397,7 +1397,7 @@
         "subtags": [
             "wiki"
         ],
-        "url": "https://github.com/farvardin/lionwiki-t2t_ynh"
+        "url": "https://github.com/YunoHost-Apps/lionwiki-t2t_ynh"
     },
     "lstu": {
         "branch": "master",


### PR DESCRIPTION
in YunoHost-Apps organisation