### PR TITLE
Draft for an autopatch 'framework'

### DIFF
--- a/autopatches/autopatch.py
+++ b/autopatches/autopatch.py
@@ -5,11 +5,6 @@ import requests
 import os
 import subprocess
 
-# ./autopatch.py --rebuild-cache
-# ./autopatch.py --apply my_patch
-# ./autopatch.py --diff
-# ./autopatch.py --push my_patch
-
 catalog = requests.get("https://raw.githubusercontent.com/YunoHost/apps/master/apps.json").json()
 
 my_env = os.environ.copy()
@@ -83,10 +78,14 @@ def apply(patch):
 def diff():
 
     for app in apps():
-        print(app["id"])
-        print("----------------------------")
         folder = os.path.join(".apps_cache", app["id"])
-        os.system(f"cd {folder} && git diff && echo $?")
+        if bool(subprocess.check_output(f"cd {folder} && git diff", shell=True).strip().decode("utf-8")):
+            print("\n\n\n")
+            print("=================================")
+            print("Changes in : " + app["id"])
+            print("=================================")
+            print("\n")
+            os.system(f"cd {folder} && git diff")
 
 
 def push(patch):

--- a/autopatches/autopatch.py
+++ b/autopatches/autopatch.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python3
+import json
+import sys
+import requests
+import os
+import subprocess
+
+# ./autopatch.py --rebuild-cache
+# ./autopatch.py --apply my_patch
+# ./autopatch.py --diff
+# ./autopatch.py --push my_patch
+
+catalog = requests.get("https://raw.githubusercontent.com/YunoHost/apps/master/apps.json").json()
+
+my_env = os.environ.copy()
+my_env["GIT_TERMINAL_PROMPT"] = "0"
+os.makedirs(".apps_cache", exist_ok=True)
+
+login = open("login").read().strip()
+token = open("token").read().strip()
+github_api = "https://api.github.com"
+
+
+def apps(min_level=4):
+
+    for app, infos in catalog.items():
+        if infos.get("state") == "working" and infos.get("level", -1) > min_level:
+            infos["id"] = app
+            yield infos
+
+
+def app_cache_folder(app):
+    return os.path.join(".apps_cache", app)
+
+
+def git(cmd, in_folder=None):
+
+    if not isinstance(cmd, list):
+        cmd = cmd.split()
+    if in_folder:
+        cmd = ["-C", in_folder] + cmd
+    cmd = ["git"] + cmd
+    return subprocess.check_output(cmd, env=my_env).strip().decode("utf-8")
+
+
+# Progress bar helper, stolen from https://stackoverflow.com/a/34482761
+def progressbar(it, prefix="", size=60, file=sys.stdout):
+    it = list(it)
+    count = len(it)
+    def show(j, name=""):
+        name += "          "
+        x = int(size*j/count)
+        file.write("%s[%s%s] %i/%i %s\r" % (prefix, "#"*x, "."*(size-x), j,  count, name))
+        file.flush()
+    show(0)
+    for i, item in enumerate(it):
+        yield item
+        show(i+1, item["id"])
+    file.write("\n")
+    file.flush()
+
+
+def build_cache():
+
+    for app in progressbar(apps(), "Git cloning: ", 40):
+        folder = os.path.join(".apps_cache", app["id"])
+        reponame = app["url"].rsplit("/", 1)
+        git(f"clone --quiet --depth 1 --single-branch {app['url']} {folder}")
+        git(f"remote add fork https://{login}:{token}@github.com/{login}/{reponame}", in_folder=folder)
+
+
+def apply(patch):
+
+    patch_path = os.path.abspath(os.path.join("patches", patch, "patch.sh"))
+
+    for app in progressbar(apps(), "Apply to: ", 40):
+        folder = os.path.join(".apps_cache", app["id"])
+        current_branch = git(f"symbolic-ref --short HEAD", in_folder=folder)
+        git(f"reset --hard origin/{current_branch}", in_folder=folder)
+        os.system(f"cd {folder} && bash {patch_path}")
+
+
+def diff():
+
+    for app in apps():
+        print(app["id"])
+        print("----------------------------")
+        folder = os.path.join(".apps_cache", app["id"])
+        os.system(f"cd {folder} && git diff && echo $?")
+
+
+def push(patch):
+
+    title = "[autopatch] " + open(os.path.join("patches", patch, "pr_title.md")).read().strip()
+
+    def diff_not_empty(app):
+        folder = os.path.join(".apps_cache", app["id"])
+        return bool(subprocess.check_output(f"cd {folder} && git diff", shell=True).strip().decode("utf-8"))
+
+    def app_is_on_github(app):
+        return "github.com" in app["url"]
+
+    apps_to_push = [app for app in apps() if diff_not_empty(app) and app_is_on_github(app)]
+
+    apps_to_push = [app for app in apps() if app["id"] == "piwigo"]
+
+    with requests.Session() as s:
+        s.headers.update({"Authorization": f"token {token}"})
+        for app in progressbar(apps_to_push, "Forking: ", 40):
+            app["repo"] = app["url"][len("https://github.com/"):].strip("/")
+            fork_if_needed(app["repo"], s)
+
+        for app in progressbar(apps_to_push, "Pushing: ", 40):
+            app["repo"] = app["url"][len("https://github.com/"):].strip("/")
+            app_repo_name = app["url"].rsplit("/", 1)[-1]
+            folder = os.path.join(".apps_cache", app["id"])
+            current_branch = git(f"symbolic-ref --short HEAD", in_folder=folder)
+            git(f"reset origin/{current_branch}", in_folder=folder)
+            git(["commit", "-a", "-m", title, "--author='Yunohost-Bot <>'"], in_folder=folder)
+            try:
+                git(f"remote remove fork", in_folder=folder)
+            except Exception:
+                pass
+            git(f"remote add fork https://{login}:{token}@github.com/{login}/{app_repo_name}", in_folder=folder)
+            git(f"push fork {current_branch}:{patch} --quiet --force", in_folder=folder)
+            create_pull_request(app["repo"], patch, current_branch, s)
+
+
+def fork_if_needed(repo, s):
+
+    repo_name = repo.split("/")[-1]
+    r = s.get(github_api + f"/repos/{login}/{repo_name}")
+
+    if r.status_code == 200:
+        return
+
+    r = s.post(github_api + f"/repos/{repo}/forks")
+
+    if r.status_code != 200:
+        print(r.text)
+
+
+def create_pull_request(repo, patch, base_branch, s):
+
+    PR = {"title": "[autopatch] " + open(os.path.join("patches", patch, "pr_title.md")).read().strip(),
+          "body": "This is an automatic PR\n\n" + open(os.path.join("patches", patch, "pr_body.md")).read().strip(),
+          "head": login + ":" + patch,
+          "base": base_branch,
+          "maintainer_can_modify": True}
+
+    r = s.post(github_api + f"/repos/{repo}/pulls", json.dumps(PR))
+
+    if r.status_code != 200:
+        print(r.text)
+    else:
+        json.loads(r.text)["html_url"]
+
+
+def main():
+
+    action = sys.argv[1]
+    if action == "--help":
+        print("""
+    Example usage:
+
+# Init local git clone for all apps
+./autopatch --build-cache
+
+# Apply patch in all local clones
+./autopatch --apply explicit-php-version-in-deps
+
+# Inspect diff for all apps
+./autopatch --diff
+
+# Push and create pull requests on all apps with non-empty diff
+./autopatch --push explicit-php-version-in-deps
+""")
+
+    elif action == "--build-cache":
+        build_cache()
+    elif action == "--apply":
+        apply(sys.argv[2])
+    elif action == "--diff":
+        diff()
+    elif action == "--push":
+        push(sys.argv[2])
+    else:
+        print("Unknown action %s" % action)
+
+
+main()

--- a/autopatches/autopatch.py
+++ b/autopatches/autopatch.py
@@ -102,8 +102,6 @@ def push(patch):
 
     apps_to_push = [app for app in apps() if diff_not_empty(app) and app_is_on_github(app)]
 
-    apps_to_push = [app for app in apps() if app["id"] == "piwigo"]
-
     with requests.Session() as s:
         s.headers.update({"Authorization": f"token {token}"})
         for app in progressbar(apps_to_push, "Forking: ", 40):

--- a/autopatches/patches/explicit-php-version-in-deps/patch.sh
+++ b/autopatches/patches/explicit-php-version-in-deps/patch.sh
@@ -1,0 +1,12 @@
+PHP_DEPS="php-bcmath php-cli php-curl php-dev php-gd php-gmp php-imap php-intl php-json php-ldap php-mbstring php-mysql php-soap php-sqlite3 php-tidy php-xml php-xmlrpc php-zip php-dom php-opcache php-xsl php-apcu php-geoip php-imagick php-memcached php-redis php-ssh2 php-common"
+
+grep -q -nr "php-" scripts/* || exit 0
+
+for DEP in $PHP_DEPS
+do
+    NEWDEP=$(echo $DEP | sed 's/php-/php7.0-/g')
+    [ ! -e ./scripts/_common.sh ] || sed "/^\s*#/!s/$DEP/$NEWDEP/g" -i ./scripts/_common.sh
+    [ ! -e ./scripts/install ]    || sed "/^\s*#/!s/$DEP/$NEWDEP/g" -i ./scripts/install
+    [ ! -e ./scripts/upgrade ]    || sed "/^\s*#/!s/$DEP/$NEWDEP/g" -i ./scripts/upgrade
+    [ ! -e ./scripts/restore ]    || sed "/^\s*#/!s/$DEP/$NEWDEP/g" -i ./scripts/restore
+done

--- a/autopatches/patches/explicit-php-version-in-deps/pr_body.md
+++ b/autopatches/patches/explicit-php-version-in-deps/pr_body.md
@@ -1,0 +1,1 @@
+(This a test for now, please ignore, sorry for the noise)

--- a/autopatches/patches/explicit-php-version-in-deps/pr_title.md
+++ b/autopatches/patches/explicit-php-version-in-deps/pr_title.md
@@ -1,0 +1,1 @@
+Explicitly version for php dependencies


### PR DESCRIPTION
Follow-up of https://github.com/YunoHost/issues/issues/1627 and discussions about the possibility to patch apps massively and automatically

So here's a draft of script that git clones all apps with level >= 4, apply a patch, and create a corresponding PR on all repos.

Usage looks like this : 

```
# Init local git clone for all apps
./autopatch --build-cache

# Apply patch in all local clones
./autopatch --apply explicit-php-version-in-deps

# Inspect diff for all apps
./autopatch --diff

# Push and create pull requests on all apps with non-empty diff
./autopatch --push explicit-php-version-in-deps
```

Resulting PR looks like this : https://github.com/YunoHost-Apps/piwigo_ynh/pull/56