### PR TITLE
Riot is now Element

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -648,6 +648,17 @@
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/dynette_ynh"
     },
+    "element": {
+        "branch": "master",
+        "category": "communication",
+        "level": 7,
+        "revision": "HEAD",
+        "state": "working",
+        "subtags": [
+            "chat"
+        ],
+        "url": "https://github.com/YunoHost-Apps/element_ynh"
+    },
     "emailpoubelle": {
         "branch": "master",
         "category": "small_utilities",
@@ -2486,15 +2497,15 @@
         "url": "https://github.com/YunoHost-Apps/restic_ynh"
     },
     "riot": {
-        "branch": "master",
+        "branch": "riot_force_migration",
         "category": "communication",
         "level": 7,
-        "revision": "HEAD",
+        "revision": "f105847",
         "state": "working",
         "subtags": [
             "chat"
         ],
-        "url": "https://github.com/YunoHost-Apps/riot_ynh"
+        "url": "https://github.com/YunoHost-Apps/element_ynh"
     },
     "roadiz": {
         "branch": "master",


### PR DESCRIPTION
Following https://github.com/YunoHost-Apps/riot_ynh/issues/23 I purpose to rename when this PR is approved the riot repository to element.

The idea is to inform the user that he need to migrate to element. So he will need to remove riot and install element. But it should not be a problem as this app contains no data on server side.