### PR TITLE
Jappix level 4

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1265,7 +1265,7 @@
     "jappix": {
         "branch": "master",
         "category": "communication",
-        "level": 7,
+        "level": 4,
         "maintained": false,
         "revision": "611170f1575603e65225b4b353f61884c7b0b42e",
         "state": "working",


### PR DESCRIPTION
Ugh sorry for jumping late after https://github.com/YunoHost/apps/pull/977 but jappix is still supposed to be level 4 according to https://ci-apps.yunohost.org/ci/job/2088

(But i noticed a few times the CI reporting level 7 even though it clearly failed package linter ..) 