### PR TITLE
Set mywebapp and etherpad as maintained

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -726,9 +726,7 @@
     "etherpad_mypads": {
         "branch": "master",
         "category": "office",
-        "high_quality": true,
         "level": 7,
-        "maintained": false,
         "revision": "HEAD",
         "state": "working",
         "subtags": [
@@ -1937,9 +1935,7 @@
     "my_webapp": {
         "branch": "master",
         "category": "publishing",
-        "high_quality": true,
         "level": 7,
-        "maintained": false,
         "revision": "HEAD",
         "state": "working",
         "subtags": [


### PR DESCRIPTION
Soooo follow-up of a discussion during a meeting from a while ago

People are confused by the 'not maintained' warning on app catalog about this app ... and each time I end up explaining that "well it's flagged as not maintained but that's not so worrysome and the app is de-facto maintained by the community"

The discussion extended to really differentating between "not maintained" (nobody explicitly maintaining the app + no significant update ~recently) versus "orphaned" (nobody explicitly maintaining the app but the app being maintained by the community overall) ... but I'm a bit lazy to dig into this right now. Also when you start digging this topic, turns out that a lot of app's effective maintainer is not the person mentioned in the manifest.json anymore which raises more questions on how to handle this topic properly.

Anyway for now I just propose to re-flag mywebapp and etherpad as maintained (though this could be discussed for other level 7 non-maintained apps as well but at least these two are high-profile) - and removing the 'high quality' flag considering we have no explicit maintainer for these ..?