### PR TITLE
Set revision for couchpotato, owntracks, phpldapadmin and wetty

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -449,7 +449,7 @@
         "category": "multimedia",
         "level": 7,
         "maintained": false,
-        "revision": "2fbe760a038a1e65f574d30ffb293c7499229235",
+        "revision": "HEAD",
         "state": "working",
         "subtags": [
             "download"
@@ -2183,7 +2183,7 @@
         "branch": "master",
         "category": "small_utilities",
         "level": 7,
-        "revision": "58da7a42b7286a0ff6a8dda6ecfb6f1ac218cbe9",
+        "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/owntracks_ynh"
     },
@@ -2280,7 +2280,7 @@
         "branch": "master",
         "category": "system_tools",
         "level": 7,
-        "revision": "5821adbc81f364a50e665eb5b196a099cd9e416e",
+        "revision": "HEAD",
         "state": "working",
         "subtags": [
             "db"
@@ -3282,7 +3282,7 @@
     "wetty": {
         "branch": "master",
         "level": 7,
-        "revision": "39da33232b805b1524847b0d1bfa44f10f2aed83",
+        "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/wetty_ynh"
     },


### PR DESCRIPTION
Some of these have quite a lot of significant commits since the commit flagged here ...

Really tempted to report using HEAD as an error in linter because having to check for this manually is just a waste of time