### PR TITLE
Flag timeoff as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3050,10 +3050,9 @@
     "timeoff": {
         "branch": "master",
         "category": "productivity_and_management",
-        "level": 0,
         "maintained": false,
         "revision": "25925abef093ac18f077326c3e7cb0dec9e0cb9b",
-        "state": "working",
+        "state": "notworking",
         "subtags": [
             "business_and_ngos"
         ],


### PR DESCRIPTION
Timeoff is level 0 since January : https://dash.yunohost.org/appci/app/timeoff

Last relevant commits are from April 2018 ...