### PR TITLE
Update high quality checklist (c.f. new definitions for level 7, 8, 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,31 +50,11 @@ Usage:
 
 ### How to make my app a High Quality app ?
 
-A High Quality app will be highlighted in the app list and marked as a level 8 app.  
-To become a High Quality app, a package has to follow the following rules:
+A High Quality app will be highlighted in the app list and marked as a level 9 app.  
+To become a High Quality app, a package has to follow the criterias listed [here](hq_validation_template.md).
 
-* The app should already have been in the community list for 2 months.
-* The app should be kept up to date, regarding the upstream source (if it’s possible with our current YunoHost version).
-* The package itself should be up to date regarding the packaging recommendations and helpers.
-* The package should be level 7 for at least 1 month.
-* The repository should have testing and master branches, at least. The list should point to HEAD, so the list stays up to date.
-* Any modification should be done to the testing branch, and wait at least for one approval of one member of the Apps group so that we can ensure that there’s nothing in opposition to those criteria, nor any changes that would harm servers.
-* The package should comply with the [requirements of the level 8](https://github.com/YunoHost/doc/blob/master/packaging_apps_levels.md#level-8).
-
-You can find the validation form used by Apps group [here](https://github.com/YunoHost/apps/blob/master/hq_validation_template.md).
-
-If the app is already tagged as High Quality and one of those criteria isn't respected anymore: after a warning, the tag will be removed until the criterion is again validated.
-
-To make an app a High Quality app, technically, you have to add the tag ```"high_quality": true```.
-```json
-    "wallabag": {
-        "branch": "master",
-        "high_quality": true,
-        "revision": "HEAD",
-        "url": "https://github.com/abeudin/wallabag_ynh.git",
-        "state": "working"
-    }
-```
+Once the app is validated is "high quality", the tag `"high_quality": true`
+shall be added to the app infos inside the catalog (`apps.json`).
 
 ### How to make my app a Featured app ?
 

--- a/hq_validation_template.md
+++ b/hq_validation_template.md
@@ -1,26 +1,22 @@
 # Validation template for High Quality tag request
 
-Package URL: 
+Package URL:
 
-This template is designed to be used as it is by Apps group to validate requests from packagers for the tag High Quality.
+This template is designed to be used by the Apps group to validate requests from packagers for the tag High Quality.
 
-Mandatory check boxes:
-- [ ] The package is level 7.
-- [ ] The package has been level 7 for at least 1 month.
-- [ ] The package has been in the list for at least 2 months.
-- [ ] The package is up to date regarding the packaging recommendations and helpers.
-- [ ] The repository has a testing branch.
-- [ ] All commits are made in testing branch before being merged into master.
-- [ ] The list points to HEAD, not to a specific commit.
-- [ ] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md)
-- [ ] The package shows the YunoHost tile `yunohost_panel.conf.inc`
-
-Optional check boxes:
-- [ ] The package is level 7 for ARM as well.
-*If the app is really important for the community, we can accept it with a broken ARM support. But this should be clearly explained and managed.*
-- [ ] The app is up to date with the upstream version.  
-*If this is possible with the last YunoHost version.*
-- [ ] The package supports LDAP  
-*If the app upstream supports it*
-- [ ] The package supports HTTP authentication  
-*If the app upstream supports it*
+- [ ] The package is level 8.
+- [ ] The app is reasonably up to date with the upstream version.
+- [ ] The maintainers intend to maintain the app, and will communicate with the Apps group if they intend to stop maintaining the app.
+- [ ] The package **supports all recommended integrations with Yunohost**, in particular:
+    - [ ] Architectures: The package has been tested and validated for other architectures it's supposed to work on (in particular ARM or 32bit), or properly handles the detection of unsupported architectures at the beginning of the install script.
+    - [ ] Yunohost tile integration: The package integrates the YunoHost tile `yunohost_panel.conf.inc` in its nginx configuration.
+    - [ ] LDAP/SSO integration *(if relevant)*: The package supports LDAP authentication **and** automatic login through Yunohost's SSO.
+    - [ ] Fail2ban integration *(if relevant)*: The package provides rules to block brute force attempts on the app
+- [ ] The package has been **reviewed by members of the Apps group** to validate that:
+   - [ ] It is up to date with the recommended packaging practices.
+   - [ ] There are no obvious security issues or borderline practices.
+- [ ] The maintainers agree to follow the **recommended development workflow**:
+   - [ ] The `revision` field in the app catalog (`apps.json`) points to `HEAD`
+   - [ ] All pull requests should target the `testing` branch before being merged into `master`.
+   - [ ] All pull requests should be reviewed and validated by another member of the app group before merging.
+   - [ ] The repository has a [`pull_request_template.md`](https://github.com/YunoHost/apps/blob/master/pull_request_template-HQ-apps.md).


### PR DESCRIPTION
c.f. the ongoing discussion to rework the definition of level 7, 8 and 9

- I removed the items that should now be handled by level 7 and 8 from the "high quality" definition
- I reworked some wording / formatting  for the existing criterias
- I added some criterias which I think should be relevant nowadays, such as fail2ban integration (if relevant) and explicitly encouraging the reviewers to look for any obvious security issue or borderline practice (during the initial validation process).
- I removed the duplicate explanation inside the README about the exact criterias and instead pointed to the hq_validation_template.md, because it's hell to maintain both things