### PR TITLE
tvheadend not being properly tested by the CI

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3150,7 +3150,7 @@
     "tvheadend": {
         "branch": "master",
         "category": "multimedia",
-        "level": 5,
+        "level": 0,
         "revision": "HEAD",
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/tvheadend_ynh"


### PR DESCRIPTION
It's been months since that app had a test on the CI that did not hang indefinitely ... So Im proposing to flag it level 0 until this is fixed (otherwise there's no proof that it really is level 5 ...)

The app itself has not really been updated for a year