### PR TITLE
Flag htmltool(s) as not working

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1233,7 +1233,7 @@
         "level": 0,
         "maintained": false,
         "revision": "f18ed28892f1eb15ef39a9cd9de9c43612f15d2d",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/isserterrus/htmltools_ynh"
     },
     "htpc-manager": {


### PR DESCRIPTION
htmltool has been level 3 since 2018, then level 0 since May and is not maintained ... Proposing to flag it as notworking