### PR TITLE
Add Dendrite

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -496,6 +496,16 @@
         ],
         "url": "https://github.com/YunoHost-Apps/democracyos_ynh"
     },
+    "dendrite": {
+        "branch": "master",
+        "category": "communication",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "subtags": [
+            "chat"
+        ],
+        "url": "https://github.com/YunoHost-Apps/dendrite_ynh"
+    },
     "diagramsnet": {
         "branch": "master",
         "category": "office",


### PR DESCRIPTION
Add Dendrite, Synapse alternative to our catalog.

App is still `inprogress` though, there are plenty of features to integrate and small problems to iron out. ;)

Closes YunoHost/doc/pull/1471 😛 