### PR TITLE
From pilea to aeneria

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -53,6 +53,13 @@
         ],
         "url": "https://github.com/YunoHost-Apps/adminer_ynh"
     },
+    "aeneria": {
+        "branch": "master",
+        "category": "iot",
+        "revision": "HEAD",
+        "state": "working",
+        "url": "https://github.com/YunoHost-Apps/aeneria_ynh"
+    },
     "agendav": {
         "branch": "master",
         "category": "synchronization",
@@ -2367,14 +2374,6 @@
             "network"
         ],
         "url": "https://github.com/YunoHost-Apps/pihole_ynh"
-    },
-    "pilea": {
-        "branch": "master",
-        "category": "iot",
-        "level": 7,
-        "revision": "HEAD",
-        "state": "working",
-        "url": "https://github.com/YunoHost-Apps/pilea_ynh"
     },
     "piratebox": {
         "branch": "master",


### PR DESCRIPTION
## Problem
There's some breaking change between the last version of Pilea and the first version of [æneria](https://gitlab.com/aeneria/aeneria-app) (which is the new Pilea name).

It would be very complicated to make a proper migration for the yunohost package and I've no time to do it.

## Solution
Instead, based on what was done  with  'wallabag to wallabag2' migration, I propose a simple guide to migrate : https://docs.aeneria.com/fr/latest/administrateur/pilea_migration.html 

## PR Status
- [x] Code finished.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/buildStatus/icon?job=aeneria_ynh+%28SimonMellerin%29)](https://ci-apps-dev.yunohost.org/jenkins/job/aeneria_ynh%20(SimonMellerin)/)

