### PR TITLE
Add django_ynh to apps.json

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -568,6 +568,16 @@
         ],
         "url": "https://github.com/YunoHost-Apps/distbin_ynh"
     },
+    "django_ynh": {
+        "branch": "master",
+        "category": "dev",
+        "revision": "HEAD",
+        "state": "inprogress",
+        "subtags": [
+            "skeleton"
+        ],
+        "url": "https://github.com/YunoHost-Apps/django_ynh"
+    },
     "django-for-runners": {
         "branch": "master",
         "revision": "HEAD",


### PR DESCRIPTION
Glue code to package django projects as yunohost apps: https://github.com/YunoHost-Apps/django_ynh