### PR TITLE
Set tagspaces as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3368,10 +3368,9 @@
     "tagspaces": {
         "branch": "master",
         "category": "synchronization",
-        "level": 2,
         "maintained": false,
         "revision": "22afa970550cf5f1d8c21c6a1fa52fa611ae918f",
-        "state": "working",
+        "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/tagspaces_ynh"
     },
     "tailoredflow": {


### PR DESCRIPTION
I don't know how this app managed to still be level 2 after so long ... it did not get any update except for the README for **five** years. The linter is screaming a gazillion number of critical errors (which should have set the app as level 0, idk why it's level 2).

Noticed that after I saw the linter explode, which in turn deleted the entire json result.json because of lack of robustness of the new CI to this kind of situation