### PR TITLE
Downgrade synapse to level 1 ?

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3366,7 +3366,7 @@
     "synapse": {
         "branch": "master",
         "category": "communication",
-        "level": 6,
+        "level": 1,
         "revision": "HEAD",
         "state": "working",
         "subtags": [


### PR DESCRIPTION
I don't know what I'm doing but:
- many users report having their app catrastrophically removed because of failed upgrade/restore
   - c.f. https://forum.yunohost.org/t/problem-during-the-synapse-update/6776
- test from 2 days ago report the app being level 1 ... which in fact sounds unrelated because it seems to be due to a glitch in multi instance app, idk ...

But at least downgrading to level < 4 should allow for the upgrade to not be ardvertised in the webadmin until the situation about the failed upgrade is fixed