### PR TITLE
Set piratebox as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2680,7 +2680,7 @@
         "level": 1,
         "maintained": false,
         "revision": "19029e995498660035302adf0ce337cc5296bd7b",
-        "state": "working",
+        "state": "notworking",
         "subtags": [
             "network"
         ],


### PR DESCRIPTION
Piratebox upstream ain't maintained and the package has been in a disasterous state for quite some time, still surprised that it's not level 0 ... but anyway the new CI doesn't like it very much