### PR TITLE
Don't include notworking apps in built list

### DIFF
--- a/list_builder.py
+++ b/list_builder.py
@@ -11,6 +11,7 @@ import time
 now = time.time()
 
 catalog = json.load(open("apps.json"))
+catalog = {app: infos for app, infos in catalog.items() if infos.get('state') != 'notworking'}
 
 my_env = os.environ.copy()
 my_env["GIT_TERMINAL_PROMPT"] = "0"


### PR DESCRIPTION
notworking apps are pilling up and we're now at 135 notworking apps (about 1/4th of the catalog).

Not a huge issue but having them in the built list polutes many things : they make the json bigger to download and to parse, 99% they are just filtered out, they are hanging in the app_cache where i regularly grep stuff, etc...