### PR TITLE
set mopidy to working

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2172,7 +2172,7 @@
         "category": "multimedia",
         "maintained": true,
         "revision": "HEAD",
-        "state": "inprogress",
+        "state": "working",
         "subtags": [
             "music"
         ],


### PR DESCRIPTION
The app passed the CI test (https://ci-apps-dev.yunohost.org/ci/job/1184).
Only linter complains that "The application is not flagged as working in YunoHost's apps catalog"
I hope this modification will help