### PR TITLE
Set nodebb as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2375,7 +2375,7 @@
         "level": 0,
         "maintained": false,
         "revision": "HEAD",
-        "state": "working",
+        "state": "notworking",
         "subtags": [
             "forum"
         ],


### PR DESCRIPTION
Unfortunately the app never went higher than level 2, is currently level 0 and hasn't moved in 2 years

https://dash.yunohost.org/appci/app/nodebb