### PR TITLE
Set multiwebapp as inprogress to encourage using only my_webapp..

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2202,10 +2202,8 @@
     "multi_webapp": {
         "branch": "master",
         "category": "publishing",
-        "level": 6,
-        "maintained": false,
         "revision": "HEAD",
-        "state": "working",
+        "state": "inprogress",
         "subtags": [
             "websites"
         ],


### PR DESCRIPTION
c.f. https://github.com/YunoHost-Apps/multi_webapp_ynh/issues/25

There's multi_webapp and my_webapp, and no clear difference between the two ... It's confusing as hell

We should just discard multi_webapp and encourage people to use only my_webapp