### PR TITLE
Set Invidious as notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1483,7 +1483,7 @@
         "category": "social_media",
         "level": 7,
         "revision": "HEAD",
-        "state": "working",
+        "state": "notworking",
         "subtags": [
             "videos"
         ],


### PR DESCRIPTION
Setting Invidious as not working until the  upstream package gets updated to use the last version of Crystal.