### PR TITLE
Auto-update-README

### DIFF
--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -19,7 +20,7 @@ def generate_READMEs(app_path):
         print("There's no 'upstream' key in the manifest, and doc/DISCLAIMER.md doesn't exists - therefore assuming that we shall not auto-update the README.md for this app yet.")
         return
 
-    env = Environment(loader=FileSystemLoader('./templates'))
+    env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
 
     for lang, lang_suffix in [("en", ""), ("fr", "_fr")]:
 
@@ -51,4 +52,4 @@ if __name__ == "__main__":
                         help='Path to the app to generate/update READMEs for')
 
     args = parser.parse_args()
-    generate_READMEs(args.app_path)
+    generate_READMEs(Path(args.app_path))

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -17,7 +17,9 @@ def generate_READMEs(app_path):
     upstream = manifest.get("upstream", {})
 
     if not upstream and not (app_path / "doc" / "DISCLAIMER.md").exists():
-        print("There's no 'upstream' key in the manifest, and doc/DISCLAIMER.md doesn't exists - therefore assuming that we shall not auto-update the README.md for this app yet.")
+        print(
+            "There's no 'upstream' key in the manifest, and doc/DISCLAIMER.md doesn't exists - therefore assuming that we shall not auto-update the README.md for this app yet."
+        )
         return
 
     env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
@@ -41,14 +43,23 @@ def generate_READMEs(app_path):
         else:
             disclaimer = None
 
-        out = template.render(lang=lang, upstream=upstream, screenshots=screenshots, disclaimer=disclaimer, manifest=manifest)
+        out = template.render(
+            lang=lang,
+            upstream=upstream,
+            screenshots=screenshots,
+            disclaimer=disclaimer,
+            manifest=manifest,
+        )
         (app_path / f"README{lang_suffix}.md").write_text(out)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Automatically (re)generate README for apps')
-    parser.add_argument('app_path',
-                        help='Path to the app to generate/update READMEs for')
+    parser = argparse.ArgumentParser(
+        description="Automatically (re)generate README for apps"
+    )
+    parser.add_argument(
+        "app_path", help="Path to the app to generate/update READMEs for"
+    )
 
     args = parser.parse_args()
     generate_READMEs(Path(args.app_path))

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import argparse
 import json

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 
-def generate_READMEs(app_path):
+def generate_READMEs(app_path: Path):
 
     if not app_path.exists():
         raise Exception("App path provided doesn't exists ?!")

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -10,13 +10,13 @@ from jinja2 import Environment, FileSystemLoader
 
 def generate_READMEs(app_path):
 
-    if not os.path.exists(app_path):
+    if not app_path.exists():
         raise Exception("App path provided doesn't exists ?!")
 
-    manifest = json.load(open(os.path.join(app_path, "manifest.json")))
+    manifest = json.load(open(app_path / "manifest.json"))
     upstream = manifest.get("upstream", {})
 
-    if not upstream and not os.path.exists(os.path.join(app_path, "doc", "DISCLAIMER.md")):
+    if not upstream and not (app_path / "doc" / "DISCLAIMER.md").exists():
         print("There's no 'upstream' key in the manifest, and doc/DISCLAIMER.md doesn't exists - therefore assuming that we shall not auto-update the README.md for this app yet.")
         return
 
@@ -26,24 +26,23 @@ def generate_READMEs(app_path):
 
         template = env.get_template(f'README{lang_suffix}.md.j2')
 
-        if os.path.exists(os.path.join(app_path, "doc", "screenshots")):
+        if (app_path / "doc" / "screenshots").exists():
             screenshots = os.listdir(os.path.join(app_path, "doc", "screenshots"))
             if ".gitkeep" in screenshots:
                 screenshots.remove(".gitkeep")
         else:
             screenshots = []
 
-        if os.path.exists(os.path.join(app_path, "doc", f"DISCLAIMER{lang_suffix}.md")):
-            disclaimer = open(os.path.join(app_path, "doc", f"DISCLAIMER{lang_suffix}.md")).read()
+        if (app_path / "doc" / f"DISCLAIMER{lang_suffix}.md").exists():
+            disclaimer = (app_path / "doc" / f"DISCLAIMER{lang_suffix}.md").read_text()
         # Fallback to english if maintainer too lazy to translate the disclaimer idk
-        elif os.path.exists(os.path.join(app_path, "doc", "DISCLAIMER.md")):
-            disclaimer = open(os.path.join(app_path, "doc", "DISCLAIMER.md")).read()
+        elif (app_path / "doc" / "DISCLAIMER.md").exists():
+            disclaimer = (app_path / "doc" / "DISCLAIMER.md").read_text()
         else:
             disclaimer = None
 
         out = template.render(lang=lang, upstream=upstream, screenshots=screenshots, disclaimer=disclaimer, manifest=manifest)
-        with open(os.path.join(app_path, f"README{lang_suffix}.md"), "w") as f:
-            f.write(out)
+        (app_path / f"README{lang_suffix}.md").write_text(out)
 
 
 if __name__ == "__main__":

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -24,7 +24,7 @@ def generate_READMEs(app_path):
 
     for lang, lang_suffix in [("en", ""), ("fr", "_fr")]:
 
-        template = env.get_template(f'README{lang_suffix}.md.j2')
+        template = env.get_template(f"README{lang_suffix}.md.j2")
 
         if (app_path / "doc" / "screenshots").exists():
             screenshots = os.listdir(os.path.join(app_path, "doc", "screenshots"))


### PR DESCRIPTION
This PR adds the following features:

## Ease of running the make_readme script from a venv
Previously, once in a venv, you'd have to run `python make_readme.py` because the shebang didn't account for env.
Now you can use `./make_readme.py`

## Ability to run the script from any folder
Previously, the templates were found relative to the shell working directory.
Now they are found relative to the script file.