### PR TITLE
Fix author and committer name for README auto-update

### DIFF
--- a/tools/README-generator/webhook.py
+++ b/tools/README-generator/webhook.py
@@ -20,9 +20,9 @@ token = open("token").read().strip()
 
 my_env = os.environ.copy()
 my_env["GIT_TERMINAL_PROMPT"] = "0"
-my_env["GIT_AUTHOR_NAME"] = "Yunohost-Bot"
+my_env["GIT_AUTHOR_NAME"] = "yunohost-bot"
 my_env["GIT_AUTHOR_EMAIL"] = "yunohost@yunohost.org"
-my_env["GIT_COMMITTER_NAME"] = "Yunohost-Bot"
+my_env["GIT_COMMITTER_NAME"] = "yunohost-bot"
 my_env["GIT_COMMITTER_EMAIL"] = "yunohost@yunohost.org"
 
 


### PR DESCRIPTION
This is a purely aesthetic matter, but it should fix the seemingly "Dr Jekyll and Mr Hyde" situation with `yunohost-bot` authoring/committing the README auto-updates:

![image](https://user-images.githubusercontent.com/8769166/132071912-88afaa48-54cb-42df-b960-7e0bb15f2425.png)
