### PR TITLE
Set TVheadend to inprogress

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3234,7 +3234,7 @@
     },
     "tvheadend": {
         "category": "multimedia",
-        "state": "notworking",
+        "state": "inprogress",
         "url": "https://github.com/YunoHost-Apps/tvheadend_ynh"
     },
     "tyto": {


### PR DESCRIPTION
Hi all,
It's been a while but I finally toke the time to upgrade and fix TVheadend package (as explained here https://github.com/YunoHost-Apps/tvheadend_ynh/issues/5#issuecomment-931337874).

Are you agree to move the app to `inprogress` state so that the CI can check it.

Thank you!