### PR TITLE
Set some apps as maintained?

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1466,7 +1466,7 @@
     "laverna": {
         "category": "office",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "text"
@@ -1484,7 +1484,7 @@
         "category": "reading",
         "high_quality": true,
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "rssreader"
@@ -1790,7 +1790,7 @@
     "minchat": {
         "category": "communication",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "chat"
@@ -2365,7 +2365,7 @@
     "phpldapadmin": {
         "category": "system_tools",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "db"
@@ -2487,7 +2487,7 @@
     "pluxml": {
         "category": "publishing",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "blog"
@@ -2829,7 +2829,7 @@
     "shellinabox": {
         "category": "system_tools",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/shellinabox_ynh"
     },
@@ -3251,7 +3251,7 @@
     "tyto": {
         "category": "productivity_and_management",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "subtags": [
             "task"
@@ -3280,7 +3280,7 @@
     "unattended_upgrades": {
         "category": "system_tools",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/unattended_upgrades_ynh"
     },
@@ -3379,7 +3379,7 @@
     "wemawema": {
         "category": "wat",
         "level": 7,
-        "maintained": false,
+        "maintained": true,
         "state": "working",
         "url": "https://github.com/Yunohost-apps/wemawema_ynh"
     },


### PR DESCRIPTION
Realized when have a bunch of apps not being level 8 because they're flagged as not-maintained in the catalog ... Despite the fact that they have significant commits in the last 6 months: 

- unattended_upgrades: https://github.com/YunoHost-Apps/unattended_upgrades_ynh/commits/master
- leed: https://github.com/YunoHost-Apps/leed_ynh/commits/testing
- pluxml: https://github.com/YunoHost-Apps/pluxml_ynh/commits/master
- phpldapadmin: https://github.com/YunoHost-Apps/phpldapadmin_ynh/commits/master
- tyto: https://github.com/YunoHost-Apps/tyto_ynh/commits/master
- wemawema: https://github.com/YunoHost-Apps/wemawema_ynh/commits/master
- laverna: https://github.com/YunoHost-Apps/laverna_ynh/commits/master
- minchat: https://github.com/YunoHost-Apps/minchat_ynh/commits/master
- shellinabox: https://github.com/YunoHost-Apps/shellinabox_ynh/commits/testing