### PR TITLE
Add Readme generator venv in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 .apps_cache
 builds
+tools/README-generator/venv/


### PR DESCRIPTION
Folder is generated following documentation, thanks command `python3 -m venv venv`.