### PR TITLE
Add Ecko (Mastodon fork)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -702,6 +702,16 @@
         ],
         "url": "https://github.com/YunoHost-Apps/easyappointments_ynh"
     },
+    "ecko": {
+        "branch": "master",
+        "category": "social_media",
+        "level": 7,
+        "state": "inprogress",
+        "subtags": [
+            "microblogging"
+        ],
+        "url": "https://github.com/YunoHost-Apps/ecko_ynh"
+    },
     "element": {
         "category": "communication",
         "level": 8,

--- a/apps.json
+++ b/apps.json
@@ -703,9 +703,7 @@
         "url": "https://github.com/YunoHost-Apps/easyappointments_ynh"
     },
     "ecko": {
-        "branch": "master",
         "category": "social_media",
-        "level": 7,
         "state": "inprogress",
         "subtags": [
             "microblogging"


### PR DESCRIPTION
Repo doesn't exist at this instant but working to transfer it from from weex/ecko_ynh to YunoHost-Apps.