### PR TITLE
Change Ecko to working state

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -707,7 +707,7 @@
     },
     "ecko": {
         "category": "social_media",
-        "state": "inprogress",
+        "state": "working",
         "subtags": [
             "microblogging"
         ],


### PR DESCRIPTION
Ecko_ynh is based on the working glitch-soc package, has been tested locally to install and remove properly and also passed @tituspijean's CI-run so this PR changes it to `working` state.