### PR TITLE
Add new app called acropolis

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -19,6 +19,16 @@
         ],
         "url": "https://github.com/YunoHost-Apps/abantecart_ynh"
     },
+    "acropolis": {
+        "category": "social_media",
+        "state": "working",
+        "subtags": [
+            "microblogging",
+            "pictures",
+            "forum"
+        ],
+        "url": "https://github.com/YunoHost-Apps/acropolis_ynh"
+    },
     "adguardhome": {
         "category": "system_tools",
         "level": 6,


### PR DESCRIPTION
Acropolis is Magic Stone's fork of diaspora* maintained via the Collective Code Construction Contract.

This package is basically still diaspora* at this point so would work if someone wants to create a diaspora* app for it.