### PR TITLE
Add Odoo

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2210,6 +2210,14 @@
         ],
         "url": "https://github.com/YunoHost-Apps/nullboard_ynh"
     },
+    "odoo": {
+        "category": "productivity_and_management",
+        "state": "working",
+        "subtags": [
+            "business_and_ngos"
+        ],
+        "url": "https://github.com/Yunohost-Apps/odoo_ynh"
+    },
     "ofbiz": {
         "category": "productivity_and_management",
         "maintained": false,


### PR DESCRIPTION
Adding Odoo ERP.

Side note, stated in the DISCLAIMER, it heavily promotes the use of the Entreprise edition of Odoo, which is not free nor open source. Normal use is quite possible though.