### PR TITLE
Retrieve repo url from git remote

### DIFF
--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -22,7 +22,7 @@ def generate_READMEs(app_path: str):
 
     git = configparser.ConfigParser()
     git.read(app_path / ".git/config")
-    remote = git['remote "origin"']['url']
+    remote = git.get('remote "origin"', {}).get('url', "")
     # TODO: Handle ssh remotes
     remote = re.search("(https:\/\/.*_ynh)\.git", remote)
     if remote is not None:

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -2,7 +2,9 @@
 
 import argparse
 import json
+import configparser
 import os
+import re
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -17,6 +19,15 @@ def generate_READMEs(app_path: str):
 
     manifest = json.load(open(app_path / "manifest.json"))
     upstream = manifest.get("upstream", {})
+
+    git = configparser.ConfigParser()
+    git.read(app_path / ".git/config")
+    remote = git['remote "origin"']['url']
+    print(remote)
+    # TODO: Handle ssh remotes
+    remote = re.search("(https:\/\/.*_ynh)\.git", remote)
+    if remote is not None:
+        remote = remote.group(0)
 
     if not upstream and not (app_path / "doc" / "DISCLAIMER.md").exists():
         print(
@@ -60,6 +71,7 @@ def generate_READMEs(app_path: str):
             screenshots=screenshots,
             disclaimer=disclaimer,
             manifest=manifest,
+            remote=remote
         )
         (app_path / f"README{lang_suffix}.md").write_text(out)
 

--- a/tools/README-generator/make_readme.py
+++ b/tools/README-generator/make_readme.py
@@ -23,11 +23,10 @@ def generate_READMEs(app_path: str):
     git = configparser.ConfigParser()
     git.read(app_path / ".git/config")
     remote = git['remote "origin"']['url']
-    print(remote)
     # TODO: Handle ssh remotes
     remote = re.search("(https:\/\/.*_ynh)\.git", remote)
     if remote is not None:
-        remote = remote.group(0)
+        remote = remote.group(1)
 
     if not upstream and not (app_path / "doc" / "DISCLAIMER.md").exists():
         print(

--- a/tools/README-generator/templates/README.md.j2
+++ b/tools/README-generator/templates/README.md.j2
@@ -68,9 +68,9 @@ Please send your pull request to the [testing branch](https://github.com/YunoHos
 
 To try the testing branch, please proceed like that.
 ```
-sudo yunohost app install https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing --debug
+sudo yunohost app install {% if remote %}{{ remote }}{% else %}https://github.com/YunoHost-Apps/{{manifest.id}}_ynh{% endif %}/tree/testing --debug
 or
-sudo yunohost app upgrade {{manifest.id}} -u https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing --debug
+sudo yunohost app upgrade {{manifest.id}} -u {% if remote %}{{ remote }}{% else %}https://github.com/YunoHost-Apps/{{manifest.id}}_ynh{% endif %}/tree/testing --debug
 ```
 
 **More info regarding app packaging:** https://yunohost.org/packaging_apps

--- a/tools/README-generator/templates/README_fr.md.j2
+++ b/tools/README-generator/templates/README_fr.md.j2
@@ -50,9 +50,9 @@ Merci de faire vos pull request sur la [branche testing](https://github.com/Yuno
 
 Pour essayer la branche testing, procédez comme suit.
 ```
-sudo yunohost app install https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing --debug
+sudo yunohost app install {% if remote %}{{ remote }}{% else %}https://github.com/YunoHost-Apps/{{manifest.id}}_ynh{% endif %}/tree/testing --debug
 ou
-sudo yunohost app upgrade {{manifest.id}} -u https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing --debug
+sudo yunohost app upgrade {{manifest.id}} -u {% if remote %}{{ remote }}{% else %}https://github.com/YunoHost-Apps/{{manifest.id}}_ynh{% endif %}/tree/testing --debug
 ```
 
 **Plus d'infos sur le packaging d'applications :** https://yunohost.org/packaging_apps


### PR DESCRIPTION
Attempt to solve https://github.com/YunoHost/issues/issues/1963

It retrieves the origin repo url from `.git/config`. Defaults to assumed Github URL if detection fails.

TODO:
- [ ] Handle SSH remotes conversion into https (handle ssh remotes with ports like `ssh://git@gitlab.domainepublic.net:3265/Neutrinet/neutrinet_ynh.git`)
  * https://stackoverflow.com/a/22312124
  * `alias fix-github-origin="git remote set-url --push origin git@github.com:\$(git remote -v | grep \"origin.*push\" | sed 's@https://@@g' | sed 's@\.com@@g' | tr '/:.' ' ' | awk '{print \$3\"/\"\$4}').git"`
