### PR TITLE
Remove Bozon from catalog

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -285,6 +285,18 @@
         ],
         "url": "https://github.com/YunoHost-Apps/borgserver_ynh"
     },
+    "bozon": {
+        "antifeatures": [
+            "deprecated-software"
+        ],
+        "category": "synchronization",
+        "level": 6,
+        "state": "working",
+        "subtags": [
+            "files"
+        ],
+        "url": "https://github.com/YunoHost-Apps/bozon_ynh"
+    },
     "cachet": {
         "category": "system_tools",
         "level": 6,

--- a/apps.json
+++ b/apps.json
@@ -285,15 +285,6 @@
         ],
         "url": "https://github.com/YunoHost-Apps/borgserver_ynh"
     },
-    "bozon": {
-        "category": "synchronization",
-        "level": 6,
-        "state": "working",
-        "subtags": [
-            "files"
-        ],
-        "url": "https://github.com/YunoHost-Apps/bozon_ynh"
-    },
     "cachet": {
         "category": "system_tools",
         "level": 6,


### PR DESCRIPTION
Bozon upstream seems not maintained anymore (last commit on 7 Nov 2018)
What to do with https://github.com/YunoHost-Apps/bozon_ynh ?