### PR TITLE
removing django_ynh

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -634,15 +634,6 @@
         ],
         "url": "https://github.com/Jojo144/django_app_ynh"
     },
-    "django_ynh": {
-        "category": "dev",
-        "level": 1,
-        "state": "working",
-        "subtags": [
-            "skeleton"
-        ],
-        "url": "https://github.com/YunoHost-Apps/django_ynh"
-    },
     "docker-registry": {
         "category": "system_tools",
         "state": "notworking",


### PR DESCRIPTION
https://github.com/YunoHost-Apps/django_ynh as been archived, so we can remove it