### PR TITLE
Remove chtickynotes_ynh

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -349,15 +349,6 @@
         "state": "working",
         "url": "https://github.com/YunoHost-Apps/cheky_ynh"
     },
-    "chtickynotes": {
-        "category": "office",
-        "level": 8,
-        "state": "working",
-        "subtags": [
-            "text"
-        ],
-        "url": "https://github.com/YunoHost-Apps/chtickynotes_ynh"
-    },
     "chuwiki": {
         "category": "publishing",
         "level": 8,


### PR DESCRIPTION
chtickynotes_ynh is a package directly including sources.
Sources are 7 years old:

- https://github.com/YunoHost-Apps/chtickynotes_ynh/tree/master/sources/libs
- https://github.com/YunoHost-Apps/chtickynotes_ynh/tree/master/sources/plugin

initial developper didn't plan to work back on the project: https://github.com/YunoHost-Apps/chtickynotes_ynh/issues/5

The code include google stuff: https://github.com/YunoHost-Apps/chtickynotes_ynh/issues/2