### PR TITLE
Add peachpub

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2580,6 +2580,14 @@
         ],
         "url": "https://github.com/YunoHost-Apps/paperless-ngx_ynh"
     },
+    "peachpub": {
+        "category": "communication",
+        "state": "inprogress",
+        "subtags": [
+            "scuttlebutt"
+        ],
+        "url": "https://github.com/YunoHost-Apps/peachpub_ynh"
+    },
     "peertube": {
         "category": "social_media",
         "level": 8,


### PR DESCRIPTION
I've been working on packaging PeachPub https://github.com/YunoHost-Apps/peachpub_ynh and the package is nearing completion. 

PeachPub is a GUI for running and managing a Scuttlebutt Pub, along with a running scuttlebutt pub. 

This has been on the yunohost apps wishlist for a long time https://yunohost.org/ar/apps_wishlist