### PR TITLE
set "django find my device" to "working" state

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -671,7 +671,7 @@
     },
     "django-find-my-device": {
         "category": "iot",
-        "state": "inprogress",
+        "state": "working",
         "url": "https://github.com/YunoHost-Apps/django-fmd_ynh"
     },
     "django-fritzconnection": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71315/179285759-83f75dcd-64e8-4272-8cbb-ca206838df96.png)

See: 

- https://ci-apps-dev.yunohost.org/ci/job/1961
- https://github.com/YunoHost-Apps/django-fmd_ynh/pull/12#issuecomment-1183503387
