### PR TITLE
Fix a bug introduced with antifeatures

### DIFF
--- a/list_builder.py
+++ b/list_builder.py
@@ -323,7 +323,7 @@ def build_app_dict(app, infos):
         "subtags": infos.get("subtags", []),
         "potential_alternative_to": infos.get("potential_alternative_to", []),
         "antifeatures": list(
-            set(manifest.get("antifeatures", []) + infos.get("antifeatures", []))
+            set(list(manifest.get("antifeatures", {}).keys()) + infos.get("antifeatures", []))
         ),
     }
 


### PR DESCRIPTION
A user [reported on the forum](https://forum.yunohost.org/t/code-server-vs-code-in-your-browser/16286/6?u=tagada) that `code-server` was not in the catalog anymore.
This is a bug introduced in `list_builder.py` with the Anti-Feature feature.
```
  File "list_builder.py", line 329, in build_app_dict
    set(manifest.get("antifeatures", []) + infos.get("antifeatures", []))
TypeError: unsupported operand type(s) for +: 'dict' and 'list'
```
This happens when the `antifeatures` in the manifest is a dict.