### PR TITLE
Change peachpub to notworking

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3117,7 +3117,7 @@
     "peachpub": {
         "category": "communication",
         "level": 7,
-        "state": "working",
+        "state": "notworking",
         "subtags": [
             "scuttlebutt"
         ],


### PR DESCRIPTION
Since publishing the app, some bugs in its underlying dependency on go-ssb have been discovered, which make the app not very stable for many usecases. 

More info is [here](https://viewer.scuttlebot.io/%25Z2V6JZDKvM2NkrcPyL9rvlSMobOBsSxDMCRM27PvtD4%3D.sha256)

For now I think it makes more sense to mark the app as "notworking", 
and to change it back to "working" once these issues are resolved. 