### PR TITLE
Add yunohost-bot forks cleanup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .apps_cache
 builds
 tools/README-generator/venv/
+tools/bot-repo-cleanup/.github_token
 
 tools/autopatches/login
 tools/autopatches/token

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -1,0 +1,28 @@
+#!venv/bin/python3
+
+from github import Github
+from github.Workflow import Workflow
+
+# API token for yunohost-bot, with "delete_repo" right
+g = Github("TOKEN_REPLACE_ME")
+u = g.get_user("yunohost-bot")
+
+print("| Repository ".ljust(22) + " | Decision |")
+print("| ".ljust(22, '-')       + " | -------- |")
+
+for repo in u.get_repos():
+    delete = False
+    if repo.parent.full_name.split('/')[0] == "YunoHost-Apps":
+        prs = []
+        for pr in repo.parent.get_pulls(state='open', sort='created'):
+            prs.append(pr)
+        if not any([ (pr.user == u) for pr in prs ]):
+            delete = True
+    else:
+        print("| "+repo.name.ljust(20) + " | Skipping |")
+        continue
+    if delete:
+        print("| "+repo.name.ljust(20) + " | Deleting |")
+        repo.delete()
+    else:
+        print("| "+repo.name.ljust(20) + " | Keeping  |")

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -5,7 +5,7 @@ from github import Github
 from github.Workflow import Workflow
 
 # API token for yunohost-bot, with "delete_repo" right
-g = Github("TOKEN_REPLACE_ME")
+g = Github(open(".github_token").read().strip())
 u = g.get_user("yunohost-bot")
 
 # Let's build a minimalistic summary table

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -17,7 +17,6 @@ for repo in u.get_repos():
     # Proceed iff the repository is a fork (`parent` key is set) of a repository in our apps organization
     if repo.parent.full_name.split('/')[0] != "YunoHost-Apps":
         print("| "+repo.name.ljust(20) + " | Skipping |")
-        continue
     else:
         # If none of the PRs are opened by the bot, delete the repository
         if not any([ (pr.user == u) for pr in list(repo.parent.get_pulls(state='open', sort='created')) ]):

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -1,5 +1,6 @@
 #!venv/bin/python3
 
+# Obtained with `pip install PyGithub`, better within a venv
 from github import Github
 from github.Workflow import Workflow
 
@@ -7,15 +8,21 @@ from github.Workflow import Workflow
 g = Github("TOKEN_REPLACE_ME")
 u = g.get_user("yunohost-bot")
 
+# Let's build a minimalistic summary table
 print("| Repository ".ljust(22) + " | Decision |")
 print("| ".ljust(22, '-')       + " | -------- |")
 
+# For each repositories belonging to the bot (user `u`), assume we will not delete it
 for repo in u.get_repos():
     delete = False
+    # Proceed iff the repository is a fork (`parent` key is set) of a repository in our apps organization
     if repo.parent.full_name.split('/')[0] == "YunoHost-Apps":
         prs = []
+        # Build the list of PRs currently opened in the repository
+        # (the get_pulls method returns an iterable, not the full list)
         for pr in repo.parent.get_pulls(state='open', sort='created'):
             prs.append(pr)
+        # If none of the PRs are opened by the bot, delete the repository
         if not any([ (pr.user == u) for pr in prs ]):
             delete = True
     else:

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -12,24 +12,16 @@ u = g.get_user("yunohost-bot")
 print("| Repository ".ljust(22) + " | Decision |")
 print("| ".ljust(22, '-')       + " | -------- |")
 
-# For each repositories belonging to the bot (user `u`), assume we will not delete it
+# For each repositories belonging to the bot (user `u`)
 for repo in u.get_repos():
-    delete = False
     # Proceed iff the repository is a fork (`parent` key is set) of a repository in our apps organization
-    if repo.parent.full_name.split('/')[0] == "YunoHost-Apps":
-        prs = []
-        # Build the list of PRs currently opened in the repository
-        # (the get_pulls method returns an iterable, not the full list)
-        for pr in repo.parent.get_pulls(state='open', sort='created'):
-            prs.append(pr)
-        # If none of the PRs are opened by the bot, delete the repository
-        if not any([ (pr.user == u) for pr in prs ]):
-            delete = True
-    else:
+    if repo.parent.full_name.split('/')[0] != "YunoHost-Apps":
         print("| "+repo.name.ljust(20) + " | Skipping |")
         continue
-    if delete:
-        print("| "+repo.name.ljust(20) + " | Deleting |")
-        repo.delete()
     else:
-        print("| "+repo.name.ljust(20) + " | Keeping  |")
+        # If none of the PRs are opened by the bot, delete the repository
+        if not any([ (pr.user == u) for pr in list(repo.parent.get_pulls(state='open', sort='created')) ]):
+            print("| "+repo.name.ljust(20) + " | Deleting |")
+            repo.delete()
+        else:
+            print("| "+repo.name.ljust(20) + " | Keeping  |")


### PR DESCRIPTION
Cleanup script to delete forks created by @yunohost-bot that are not used anymore.

It lists all repositories belonging to the bot, and filters out repositories that are not forks of the YunoHost-Apps organization and those which still have an unmerged PR opened by the bot.

Contributions are welcome, I am sure that code can be optimized.
Namely, I had to run it four times to get all repositories, which is a bit unexpected considering the use of PyGithub.