### PR TITLE
Akkoma is in working state

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -119,7 +119,7 @@
             "Mastodon",
             "Pleroma"
         ],
-        "state": "inprogress",
+        "state": "working",
         "subtags": [
             "microblogging"
         ],


### PR DESCRIPTION
Install, remove, backup, restore, upgrade are working.

This should bump it to level 7.