### PR TITLE
statping ng : the app in manifest should be the same as the manifest id ...

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4361,10 +4361,10 @@
         "state": "notworking",
         "url": "https://github.com/YunoHost-Apps/staticwebapp_ynh"
     },
-    "statping_ng": {
+    "statpingng": {
         "category": "system_tools",
         "state": "working",
-        "url": "https://github.com/YunoHost-Apps/statping_ng_ynh"
+        "url": "https://github.com/YunoHost-Apps/statpingng_ynh"
     },
     "streama": {
         "category": "multimedia",


### PR DESCRIPTION
(and also the github repo needs to be renamed too ... https://github.com/YunoHost-Apps/statping_ng_ynh )