### PR TITLE
Set snserver and snweb to not maintained.

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3143,6 +3143,7 @@ subtags = [ "business_and_ngos" ]
 url = "https://github.com/YunoHost-Apps/snipeit_ynh"
 
 [snserver]
+antifeatures = [ "package-not-maintained" ]
 category = "office"
 level = 8
 state = "working"
@@ -3150,6 +3151,7 @@ subtags = [ "text" ]
 url = "https://github.com/YunoHost-Apps/snserver_ynh"
 
 [snweb]
+antifeatures = [ "package-not-maintained" ]
 category = "office"
 level = 8
 state = "working"


### PR DESCRIPTION
Standard Notes is a great App for writing notes, but I dont have enogh time to keep-up with the changes in the upstream source code.

To get everything working, there has to be removed an old services and added a four new services, as well as other changes in the code.
There are some problems with the server that make the app not fully functional. Such as the file upload and download.

The latest change by the developers now ensures that the extensions are no longer available free of charge for self-hosters. Which will probably reduce the use of the ynh server and web app packages as well.
However, this only applies to client apps from a certain version.
https://standardnotes.com/blog/making-self-hosting-easy-for-all
antifeatures = [ "not-totally-free" ] must therefore probably also be added.


If someone else would like to continue the ynh packages, I'm happy to help if needed.