### PR TITLE
Rainloop is unmaintained and has CVE-2022-29360 unpatched.

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2853,6 +2853,7 @@ level = 8
 potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
 state = "working"
 subtags = [ "email" ]
+antifeatures = [ "bad-security-reputation" ]
 url = "https://github.com/YunoHost-Apps/rainloop_ynh"
 
 [redirect]

--- a/apps.toml
+++ b/apps.toml
@@ -2853,7 +2853,7 @@ level = 8
 potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
 state = "working"
 subtags = [ "email" ]
-antifeatures = [ "bad-security-reputation" ]
+antifeatures = [ "bad-security-reputation", "deprecated-software", "replaced-by-another-app" ]
 url = "https://github.com/YunoHost-Apps/rainloop_ynh"
 
 [redirect]


### PR DESCRIPTION
As per [Rainloop issue 2180](https://github.com/RainLoop/rainloop-webmail/issues/2180) Rainloop still has security issue [CVE-2022-29360](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29360).
As suggested in [rainloop_ynh issue](https://github.com/YunoHost-Apps/rainloop_ynh/issues/91) upstream is unmaintained, it's fork [SnappyMail](https://github.com/YunoHost-Apps/snappymail_ynh) should take the star.