### PR TITLE
peertube-search-index package not totally free anymore

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2476,6 +2476,7 @@ category = "social_media"
 level = 8
 state = "working"
 subtags = [ "videos" ]
+antifeatures = [ "not-totally-free" ]
 url = "https://github.com/YunoHost-Apps/peertube-search-index_ynh"
 
 [pelican]


### PR DESCRIPTION
This is due to the ElasticSearch8 dependency which is SSPL licensed

This will be effective once https://github.com/YunoHost-Apps/peertube-search-index_ynh/pull/32 is merged.