### PR TITLE
Added CyberChef to catalog

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -509,7 +509,7 @@ url = "https://github.com/YunoHost-Apps/cultivons_ynh"
 [cyberchef]
 category = "small_utilities"
 state = "in_progress"
-url = "https://github.com/oleole39/cyberchef_ynh"
+url = "https://github.com/YunoHost-Apps/cyberchef_ynh"
 
 [cypht]
 category = "communication"

--- a/apps.toml
+++ b/apps.toml
@@ -506,6 +506,12 @@ level = 7
 state = "working"
 url = "https://github.com/YunoHost-Apps/cultivons_ynh"
 
+[cyberchef]
+category = "small_utilities"
+level = 1
+state = "in_progress"
+url = "https://github.com/oleole39/cyberchef_ynh"
+
 [cypht]
 category = "communication"
 level = 7

--- a/apps.toml
+++ b/apps.toml
@@ -508,7 +508,6 @@ url = "https://github.com/YunoHost-Apps/cultivons_ynh"
 
 [cyberchef]
 category = "small_utilities"
-level = 1
 state = "in_progress"
 url = "https://github.com/oleole39/cyberchef_ynh"
 


### PR DESCRIPTION
Hello,

You will find here proposed to be added to the catalog a package for CyberChef (which incidentally is currently on the app wishlist).
I tried install/remove manual scenario with success and package linter test is successful (the only error thrown being that it does not appear in catalog).

I would require assistance on 2 aspects to improve the app's notation:
1. How to get permission to write directory at Yunohost-Apps to transfer the repo ownership?
2. Could Yunorunner test the package for all scenarios (instead of me having to set up `package_test`)? 