### PR TITLE
Ignore app_list_auto_update.log file and __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tools/autopatches/login
 tools/autopatches/token
 
 .github_token
+
+__pycache__
+app_list_auto_update.log


### PR DESCRIPTION
Using rebuild.sh create some `__pycache__` subdirectories in the tools directories and a log file at the repo root.
I think it's better to ignore those files/directories for git.