### PR TITLE
Add Jellyfin-vue to the apps list

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1648,6 +1648,13 @@ state = "working"
 subtags = [ "music", "mediacenter" ]
 url = "https://github.com/YunoHost-Apps/jellyfin_ynh"
 
+[jellyfin-vue]
+category = "multimedia"
+potential_alternative_to = [ "Plex", "Netflix" ]
+state = "working"
+subtags = [ "music", "mediacenter" ]
+url = "https://github.com/YunoHost-Apps/jellyfin-vue_ynh"
+
 [jellyseerr]
 category = "multimedia"
 level = 7


### PR DESCRIPTION
This is a Jellyfin client that does not expects Jellyfin to be already installed, but can connect to an already installed Jellyfin.