### PR TITLE
Rportd has been closed-sourced and its repository deleted

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3135,9 +3135,10 @@ subtags = [ "email" ]
 url = "https://github.com/YunoHost-Apps/roundcube_ynh"
 
 [rportd]
+antifeatures = [ "deprecated-software" ]
 category = "system_tools"
-level = 8
-state = "working"
+level = 0
+state = "notworking"
 subtags = [ "monitoring" ]
 url = "https://github.com/YunoHost-Apps/rportd_ynh"
 


### PR DESCRIPTION
cf. https://forum.yunohost.org/t/rportd-not-open-source-anymore-should-it-remain-in-the-catalog/26441 and https://github.com/realvnc-labs/rport/blob/192d76724b43fd52a95892174b63a1f45153d77f/README.md
To notify YunoHost users, I suggest to have a month-long period when we keep the app in the catalog with a notworking state and the appropriate anti-feature.