### PR TITLE
Reset YNH integration version to 1 on upstream version bumps

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -385,7 +385,7 @@ class AppAutoUpdater:
         if is_main:
 
             def repl(m):
-                return m.group(1) + new_version + m.group(3)
+                return m.group(1) + new_version + "~ynh1"
 
             content = re.sub(
                 r"(\s*version\s*=\s*[\"\'])([\d\.]+)(\~ynh\d+[\"\'])", repl, content


### PR DESCRIPTION
Reset `ynh` version part when bumping upstream version.

`2.6.2~ynh4` becomes `2.7.0~ynh1` rather than `2.7.0~ynh4`?