### PR TITLE
Remove link to the documentation

### DIFF
--- a/tools/README-generator/templates/README.md.j2
+++ b/tools/README-generator/templates/README.md.j2
@@ -72,7 +72,6 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 {% endif -%}
 {% if upstream.code -%}* Upstream app code repository: <{{ upstream.code }}>
 {% endif -%}
-* YunoHost documentation for this app: <https://yunohost.org/app_{{manifest.id}}>
 * Report a bug: <https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/issues>
 
 ## Developer info

--- a/tools/README-generator/templates/README_fr.md.j2
+++ b/tools/README-generator/templates/README_fr.md.j2
@@ -59,7 +59,6 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 {% endif -%}
 {% if upstream.code -%}* Dépôt de code officiel de l’app : <{{ upstream.code }}>
 {% endif -%}
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_{{manifest.id}}>
 * Signaler un bug : <https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/issues>
 
 ## Informations pour les développeurs


### PR DESCRIPTION
As discussed in the Apps packagers room those days, packagers should start to include documentation directly in the package (in ADMIN.md, PRE_INSTALL.md...)