### PR TITLE
Store: Explicit wishlist PR message

### DIFF
--- a/store/app.py
+++ b/store/app.py
@@ -346,7 +346,7 @@ Description: {description}
         url = f"https://github.com/YunoHost/apps/pull/{pr.number}"
 
         successmsg = _(
-            "Your proposed app has succesfully been submitted. It must now be validated by the YunoHost team. You can track progress here: %(url)s",
+            "Your proposed app has succesfully been submitted. It must now be validated by the YunoHost team. You can track progress here: <a href='%(url)s'>%(url)s</a>",
             url=url,
         )
         return render_template(

--- a/store/app.py
+++ b/store/app.py
@@ -291,9 +291,7 @@ def add_to_wishlist():
         new_branch = f"add-to-wishlist-{slug}"
         try:
             # Get the commit base for the new branch, and create it
-            commit_sha = repo.get_branch(
-                repo.default_branch
-            ).commit.sha
+            commit_sha = repo.get_branch(repo.default_branch).commit.sha
             repo.create_git_ref(ref=f"refs/heads/{new_branch}", sha=commit_sha)
         except exception as e:
             print("... Failed to create branch ?")
@@ -328,6 +326,10 @@ def add_to_wishlist():
 
 Proposed by **{session['user']['username']}**
 
+Website: {website}
+Upstream repo: {upstream}
+Description: {description}
+
 - [ ] Confirm app is self-hostable and generally makes sense to possibly integrate in YunoHost
 - [ ] Confirm app's license is opensource/free software (or not-totally-free, case by case TBD)
 - [ ] Description describes concisely what the app is/does
@@ -355,7 +357,7 @@ Proposed by **{session['user']['username']}**
         )
     else:
         letters = string.ascii_lowercase + string.digits
-        csrf_token = ''.join(random.choice(letters) for i in range(16))
+        csrf_token = "".join(random.choice(letters) for i in range(16))
         session["csrf_token"] = csrf_token
         return render_template(
             "wishlist_add.html",

--- a/store/templates/wishlist_add.html
+++ b/store/templates/wishlist_add.html
@@ -16,7 +16,7 @@
     <div role="alert" class="rounded-md border-s-4 border-green-500 bg-green-50 p-4 my-5">
       <p class="mt-2 text-sm text-green-700 font-bold">
         <i class="fa fa-thumbs-up fa-fw" aria-hidden="true"></i>
-        {{ successmsg }}
+        {{ successmsg | safe }}
       </p>
     </div>
     {% else %}


### PR DESCRIPTION
I edited the wishlist PR message to show the user entered data for `website`, `upstream `and `description`

So maintainers can easily click on links (instead of the unnecessarily annoying way to do it in the diff view)

And it makes the PR explicit at first glance, which is important


(BTW the others changes in my commit at lines [294](https://github.com/YunoHost/apps/commit/e94f301d80db72d85ae8f3b927c78e67c81cdc43#diff-6931cdc04bc4855814e1f9f16147b4d1097ebff9b4203876a23f7766c11c9d04R294) and [358](https://github.com/YunoHost/apps/commit/e94f301d80db72d85ae8f3b927c78e67c81cdc43#diff-6931cdc04bc4855814e1f9f16147b4d1097ebff9b4203876a23f7766c11c9d04R360) are due to my linter, I can remove them if necessary)