### PR TITLE
source autoupdater: Use semver for version parsing.

### DIFF
--- a/tools/autoupdate_app_sources/requirements.txt
+++ b/tools/autoupdate_app_sources/requirements.txt
@@ -1,0 +1,4 @@
+PyGithub
+requests
+toml
+semver


### PR DESCRIPTION
We currently manually parse versions in format `x.y.z`. Semver does this for us in (hopefully) less error prone way.

One caveat is that [rustdesk](https://github.com/rustdesk/rustdesk-server/releases) and probably others don't strictly follow semver, making `1.0.0a` an invalid version and `1.0.0-1` less than `1.0.0` (`1.0.0-1` is considered pre-release).