### PR TITLE
Adding Ladder to the catalog

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1759,6 +1759,12 @@ state = "working"
 subtags = [ "accounting" ]
 url = "https://github.com/YunoHost-Apps/kresus_ynh"
 
+[ladder]
+category = "reading"
+potential_alternative_to = [ "12ft", "13ft" ]
+state = "working"
+url = "https://github.com/YunoHost-Apps/ladder_ynh"
+
 [languagetool]
 category = "office"
 level = 8


### PR DESCRIPTION
Hello, 
I would like to integrate Ladder to the YunoHost catalog.

Ladder is a selfhosted alternative to 12ft.io. and 1ft.io bypass paywalls with a proxy ladder and remove CORS headers from any URL.

It is also an alternative for 13ft, which is already integrated in YunoHost but broken and has less functionalities. 

Resources : 
- https://forum.yunohost.org/t/help-for-new-app-packaging-13ft-12ft-io-alternative-bypass-paywalls/22665/20
- https://github.com/everywall/ladder
- https://github.com/Gildas-GH/ladder_ynh

I can't transfer ownership of the repository as I'm not in the Yunohost-Apps organization (but I'd like to transfer it if possible).