### PR TITLE
cjdns working status

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -388,7 +388,7 @@ url = "https://github.com/YunoHost-Apps/civicrm_drupal7_ynh"
 
 [cjdns]
 category = "system_tools"
-state = "notworking"
+state = "working"
 subtags = [ "network" ]
 url = "https://github.com/YunoHost-Apps/cjdns_ynh"
 


### PR DESCRIPTION
Hello and happy holidays everyone.
Last test show as failed https://ci-apps-dev.yunohost.org/ci/job/12055
but it passed to level 4. It is now clear for me if it is level 6 since it has not linter errors just warnings and the app is a community git repo but I guess you know better what level you should put it as.
Thanks for the help