### PR TITLE
[autoupdate] fix PR title when latest_github_release

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -240,9 +240,6 @@ class AppAutoUpdater:
             title = message = "Upgrade sources"
             new_branch = "ci-auto-update-sources"
 
-        print(f"Title: {title}")
-        print(f"Message: {message}")
-
         try:
             # Get the commit base for the new branch, and create it
             commit_sha = self.repo.get_branch(self.base_branch).commit.sha

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -230,14 +230,18 @@ class AppAutoUpdater:
 
         if "main" in todos:
             if strategy == "latest_github_release":
+                title = f"Upgrade to v{new_version}"
                 message = f"Upgrade to v{new_version}\nChangelog: {changelog_url}"
             else:
-                message = f"Upgrade to v{new_version}"
+                title = message = f"Upgrade to v{new_version}"
             new_version = todos["main"]["new_version"]
             new_branch = f"ci-auto-update-{new_version}"
         else:
-            message = "Upgrade sources"
+            title = message = "Upgrade sources"
             new_branch = "ci-auto-update-sources"
+
+        print(f"Title: {title}")
+        print(f"Message: {message}")
 
         try:
             # Get the commit base for the new branch, and create it
@@ -271,7 +275,7 @@ class AppAutoUpdater:
 
         # Open the PR
         pr = self.repo.create_pull(
-            title=message, body=message, head=new_branch, base=self.base_branch
+            title=title, body=message, head=new_branch, base=self.base_branch
         )
 
         print("Created PR " + self.repo.full_name + " updated with PR #" + str(pr.id))


### PR DESCRIPTION
Since #1960 the title include the link to the changelog when the strategy is `latest_github_release`

This PR fixes this:

using
```bash
print(f"Title: {title}")
print(f"Message: {message}")
```

```bash
$ sed -i "s/latest_github_tag/latest_github_release/" ~/git/ynh/snappymail_ynh/manifest.toml

$ python3 autoupdate_app_sources.py ~/git/ynh/snappymail_ynh/ --commit-and-create-PR

  Checking main ...
Current version in manifest: 2.29.1
Newest  version on upstream: 2.32.0
Update needed for main
Title: Upgrade to v2.32.0
Message: Upgrade to v2.32.0
Changelog: https://github.com/the-djmaze/snappymail/releases/tag/v2.32.0
... Branch already exists, skipping

$ sed -i "s/latest_github_release/latest_github_tag/" ~/git/ynh/snappymail_ynh/manifest.toml

$ python3 autoupdate_app_sources.py ~/git/ynh/snappymail_ynh/ --commit-and-create-PR

  Checking main ...
Current version in manifest: 2.29.1
Newest  version on upstream: 2.32.0
Update needed for main
Title: Upgrade to v2.32.0
Message: Upgrade to v2.32.0
... Branch already exists, skipping
```