### PR TITLE
Fix manifestv2 schema: resources.sources.*.in_subdir can also be an integer

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -371,7 +371,14 @@
                                 },
                                 "sha256": {"$ref": "#/$defs/sha256sum"},
                                 "in_subdir": {
-                                    "type": "boolean"
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
                                 },
                                 "prefetch": {
                                     "type": "boolean"


### PR DESCRIPTION
Yeah, i got an app that requires in_subdir=2…