### PR TITLE
Support for GitLab upstream repos part 2.

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -413,7 +413,10 @@
                                             "enum": [
                                                 "latest_github_tag",
                                                 "latest_github_release",
-                                                "latest_github_commit"
+                                                "latest_github_commit",
+                                                "latest_gitlab_tag",
+                                                "latest_gitlab_release",
+                                                "latest_gitlab_commit"
                                             ]
                                         },
                                         "upstream": {

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -171,7 +171,7 @@ class AppAutoUpdater:
 
             print(f"\n  Checking {source} ...")
 
-            if strategy == "latest_github_release":
+            if strategy == "latest_github_release" or strategy == "latest_gitlab_release":
                 (
                     new_version,
                     new_asset_urls,

--- a/tools/autoupdate_app_sources/rest_api.py
+++ b/tools/autoupdate_app_sources/rest_api.py
@@ -88,7 +88,9 @@ class GitlabAPI:
     def releases(self) -> List[str]:
         """Get a list of releases for project."""
         releases = self.internal_api(f"projects/{self.project_id}/releases")
-        return [{
+        retval = []
+        for release in releases:
+            r = {
                 "tag_name": release["tag_name"],
                 "prerelease": False,
                 "draft": False,
@@ -97,7 +99,15 @@ class GitlabAPI:
                     "name": asset["name"],
                     "browser_download_url": asset["direct_asset_url"]
                     } for asset in release["assets"]["links"]],
-                } for release in releases]
+                }
+            for source in release["assets"]["sources"]:
+                r["assets"].append({
+                    "name": f"source.{source['format']}",
+                    "browser_download_url": source['url']
+                })
+            retval.append(r)
+
+        return retval
 
     def url_for_ref(self, ref: str, ref_type: RefType) -> str:
         return f"{self.upstream}/api/v4/projects/{self.project_id}/repository/archive.tar.gz/?sha={ref}"


### PR DESCRIPTION
- [x] Added support for source tarballs
- [x] Fixed problem with autoupdater flow with `latest_gitlab_release` stategy
- [x] Adjusted `manifest.toml` schema