### PR TITLE
Mark joomla_ynh unmaintained for now.

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1529,6 +1529,7 @@ subtags = [ "meeting" ]
 url = "https://github.com/YunoHost-Apps/jitsi_ynh"
 
 [joomla]
+antifeatures = [ "package-not-maintained" ]
 category = "publishing"
 level = 8
 state = "working"


### PR DESCRIPTION
The version in YNH catalog is over a year old, not even the latest of 4.x releases. We should not recommend installing it.