### PR TITLE
Auto-updater: Initial support for Gitea & Forgejo

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -257,9 +257,6 @@ class AppAutoUpdater:
             title = message = "Upgrade sources"
             new_branch = "ci-auto-update-sources"
 
-        print(f"Title: {title}")
-        print(f"Message: {message}")
-
         try:
             # Get the commit base for the new branch, and create it
             commit_sha = self.repo.get_branch(self.base_branch).commit.sha

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -179,7 +179,7 @@ class AppAutoUpdater:
 
             print(f"\n  Checking {source} ...")
 
-            if "_release" in strategy:
+            if strategy.endswith("_release"):
                 (
                     new_version,
                     new_asset_urls,
@@ -246,7 +246,7 @@ class AppAutoUpdater:
             return bool(todos)
 
         if "main" in todos:
-            if "_release" in strategy:
+            if strategy.endswith("_release"):
                 title = f"Upgrade to v{new_version}"
                 message = f"Upgrade to v{new_version}\nChangelog: {changelog_url}"
             else:
@@ -256,6 +256,9 @@ class AppAutoUpdater:
         else:
             title = message = "Upgrade sources"
             new_branch = "ci-auto-update-sources"
+
+        print(f"Title: {title}")
+        print(f"Message: {message}")
 
         try:
             # Get the commit base for the new branch, and create it
@@ -311,7 +314,7 @@ class AppAutoUpdater:
         elif "gitea" in strategy or "forgejo" in strategy:
             api = GiteaForgejoAPI(upstream)
 
-        if "_release" in strategy:
+        if strategy.endswith("_release"):
             releases = api.releases()
             tags = [
                 release["tag_name"]
@@ -388,7 +391,7 @@ class AppAutoUpdater:
                         latest_release_html_url,
                     )
 
-        elif "_tag" in strategy:
+        elif strategy.endswith("_tag"):
             if asset != "tarball":
                 raise Exception(
                     "For the latest tag strategy, only asset = 'tarball' is supported"
@@ -400,7 +403,7 @@ class AppAutoUpdater:
             latest_tarball = api.url_for_ref(latest_version_orig, RefType.tags)
             return latest_version, latest_tarball
 
-        elif "_commit" in strategy:
+        elif strategy.endswith("_commit"):
             if asset != "tarball":
                 raise Exception(
                     "For the latest release strategy, only asset = 'tarball' is supported"

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -326,12 +326,22 @@ class AppAutoUpdater:
                 for release in releases
                 if release["tag_name"] == latest_version_orig
             ][0]
-            latest_assets = {
-                a["name"]: a["browser_download_url"]
-                for a in latest_release["assets"]
-                if not a["name"].endswith(".md5")
-            }
-            if strategy == "latest_gitlab_release":
+            if "github" in strategy or "gitlab" in strategy:
+                latest_assets = {
+                    a["name"]: a["browser_download_url"]
+                    for a in latest_release["assets"]
+                    if not a["name"].endswith(".md5")
+                }
+            elif "gitea" in strategy or "forgejo" in strategy:
+               latest_assets = {
+                    a["name"]: a["browser_download_url"]
+                    for a in latest_release["assets"]
+                    if not a["name"].endswith(".md5")
+                }
+               if latest_assets == "":
+                   # if empty (so only the base asset), take the tarball_url
+                   latest_assets = latest_release["tarball_url"]
+            if strategy == "_release":
                 # gitlab's API is different for that
                 latest_release_html_url = latest_release["_links"]["self"]
             else:

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -19,9 +19,12 @@ STRATEGIES = [
     "latest_gitlab_release",
     "latest_gitlab_tag",
     "latest_gitlab_commit",
-    "latest_giteaforgejo_release",
-    "latest_giteaforgejo_tag",
-    "latest_giteaforgejo_commit"
+    "latest_gitea_release",
+    "latest_gitea_tag",
+    "latest_gitea_commit",
+    "latest_forgejo_release",
+    "latest_forgejo_tag",
+    "latest_forgejo_commit"
     ]
 
 if "--commit-and-create-PR" not in sys.argv:

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -326,21 +326,14 @@ class AppAutoUpdater:
                 for release in releases
                 if release["tag_name"] == latest_version_orig
             ][0]
-            if "github" in strategy or "gitlab" in strategy:
-                latest_assets = {
-                    a["name"]: a["browser_download_url"]
-                    for a in latest_release["assets"]
-                    if not a["name"].endswith(".md5")
-                }
-            elif "gitea" in strategy or "forgejo" in strategy:
-               latest_assets = {
-                    a["name"]: a["browser_download_url"]
-                    for a in latest_release["assets"]
-                    if not a["name"].endswith(".md5")
-                }
-               if latest_assets == "":
-                   # if empty (so only the base asset), take the tarball_url
-                   latest_assets = latest_release["tarball_url"]
+            latest_assets = {
+                a["name"]: a["browser_download_url"]
+                for a in latest_release["assets"]
+                if not a["name"].endswith(".md5")
+            }
+            if ("gitea" in strategy or "forgejo" in strategy) and latest_assets == "":
+                # if empty (so only the base asset), take the tarball_url
+                latest_assets = latest_release["tarball_url"]
             if strategy == "_release":
                 # gitlab's API is different for that
                 latest_release_html_url = latest_release["_links"]["self"]

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -101,7 +101,7 @@ def filter_and_get_latest_tag(tags, app_id):
         elif t.startswith("release-"):
             t_to_check = t.split("-", 1)[-1].replace("-", ".")
 
-        if not re.match(r"^v?[\d\.]*\-?\d$", t_to_check):
+        if not re.match(r"^v?[\d\.]*\-\d$", t_to_check):
             print(f"Ignoring tag {t_to_check}, doesn't look like a version number")
         else:
             tag_dict[t] = tag_to_int_tuple(t_to_check)

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -101,7 +101,7 @@ def filter_and_get_latest_tag(tags, app_id):
         elif t.startswith("release-"):
             t_to_check = t.split("-", 1)[-1].replace("-", ".")
 
-        if not re.match(r"^v?[\d\.]*\-\d$", t_to_check):
+        if not re.match(r"^v?[\d\.]*\-?\d$", t_to_check):
             print(f"Ignoring tag {t_to_check}, doesn't look like a version number")
         else:
             tag_dict[t] = tag_to_int_tuple(t_to_check)

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -335,9 +335,6 @@ class AppAutoUpdater:
                 # if empty (so only the base asset), take the tarball_url
                 latest_assets = latest_release["tarball_url"]
             if strategy == "_release":
-                # gitlab's API is different for that
-                latest_release_html_url = latest_release["_links"]["self"]
-            else:
                 latest_release_html_url = latest_release["html_url"]
             if asset == "tarball":
                 latest_tarball = (

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -101,7 +101,7 @@ def filter_and_get_latest_tag(tags, app_id):
         elif t.startswith("release-"):
             t_to_check = t.split("-", 1)[-1].replace("-", ".")
 
-        if not re.match(r"^v?[\d\.]*\d$", t_to_check):
+        if not re.match(r"^v?[\d\.]*\-?\d$", t_to_check):
             print(f"Ignoring tag {t_to_check}, doesn't look like a version number")
         else:
             tag_dict[t] = tag_to_int_tuple(t_to_check)
@@ -112,7 +112,7 @@ def filter_and_get_latest_tag(tags, app_id):
 
 
 def tag_to_int_tuple(tag):
-    tag = tag.strip("v").strip(".")
+    tag = tag.strip("v").replace("-", ".").strip(".")
     int_tuple = tag.split(".")
     assert all(i.isdigit() for i in int_tuple), f"Cant convert {tag} to int tuple :/"
     return tuple(int(i) for i in int_tuple)

--- a/tools/autoupdate_app_sources/rest_api.py
+++ b/tools/autoupdate_app_sources/rest_api.py
@@ -118,7 +118,6 @@ class GiteaForgejoAPI:
         split = re.search("(?P<host>https?://.+)/(?P<group>[^/]+)/(?P<project>[^/]+)/?$", upstream)
         self.upstream = split.group("host")
         self.upstream_repo = f"{split.group('group')}/{split.group('project')}"
-        self.project_id = self.find_project_id(self.upstream_repo)
 
     def internal_api(self, uri: str):
         url = f"{self.upstream}/api/v1/{uri}"

--- a/tools/autoupdate_app_sources/rest_api.py
+++ b/tools/autoupdate_app_sources/rest_api.py
@@ -111,3 +111,33 @@ class GitlabAPI:
 
     def url_for_ref(self, ref: str, ref_type: RefType) -> str:
         return f"{self.upstream}/api/v4/projects/{self.project_id}/repository/archive.tar.gz/?sha={ref}"
+
+
+class GiteaForgejoAPI:
+    def __init__(self, upstream: str):
+        split = re.search("(?P<host>https?://.+)/(?P<group>[^/]+)/(?P<project>[^/]+)/?$", upstream)
+        self.upstream = split.group("host")
+        self.upstream_repo = f"{split.group('group')}/{split.group('project')}"
+        self.project_id = self.find_project_id(self.upstream_repo)
+
+    def internal_api(self, uri: str):
+        url = f"{self.upstream}/api/v1/{uri}"
+        r = requests.get(url)
+        assert r.status_code == 200, r
+        return r.json()
+
+    def tags(self) -> List[str]:
+        """Get a list of tags for project."""
+        return self.internal_api(f"repos/{self.upstream_repo}/tags")
+
+    def commits(self) -> List[str]:
+        """Get a list of commits for project."""
+        return self.internal_api(f"repos/{self.upstream_repo}/commits")
+
+    def releases(self) -> List[str]:
+        """Get a list of releases for project."""
+        return self.internal_api(f"repos/{self.upstream_repo}/releases")
+
+    def url_for_ref(self, ref: str, ref_type: RefType) -> str:
+        """Get a URL for a ref."""
+        return f"{self.upstream}/{self.upstream_repo}/archive/{ref}.tar.gz"


### PR DESCRIPTION
i've had enough https://codeberg.org/ladigitale/digisteps/issues/3

so i worked on this lmao i'm dumb

not tested for now, i'm tired

i separated gitea and forgejo (`latest_gitea_` `latest_forgejo_`), so that if one day their APIs are no longer compatible, we won't have to update all packages manifests

i simplified many if conditions, like that:
`if strategy == "latest_github_release" or strategy == "latest_gitlab_release" or strategy == "latest_gitea_release" or strategy == "latest_forgejo_release":`
`if "_release" in strategy:`
so the list is not going to be infinite :")

and now the changelog link in PR also supports gitlab (gitea and forgejo too, ofc)