### PR TITLE
add gitea and forgejo autoupdate strategies

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -416,7 +416,13 @@
                                                 "latest_github_commit",
                                                 "latest_gitlab_tag",
                                                 "latest_gitlab_release",
-                                                "latest_gitlab_commit"
+                                                "latest_gitlab_commit",
+                                                "latest_gitea_tag",
+                                                "latest_gitea_release",
+                                                "latest_gitea_commit",
+                                                "latest_forgejo_tag",
+                                                "latest_forgejo_release",
+                                                "latest_forgejo_commit"
                                             ]
                                         },
                                         "upstream": {


### PR DESCRIPTION
```
 ⓘ manifest

    - Error validating manifest using schema: in key resources > sources > main > autoupdate > strategy
       'latest_forgejo_release' is not one of ['latest_github_tag', 'latest_github_release', 'latest_github_commit', 'latest_gitlab_tag', 'latest_gitlab_release', 'latest_gitlab_commit']
```