### PR TITLE
Icecoder is deprecated

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1387,6 +1387,7 @@ url = "https://github.com/YunoHost-Apps/hydrogen_ynh"
 
 [icecoder]
 category = "dev"
+antifeatures = [ "deprecated-software" ]
 level = 7
 state = "working"
 subtags = [ "programming" ]


### PR DESCRIPTION
> This repository has been archived by the owner on Dec 14, 2023. It is now read-only.

https://github.com/icecoder/ICEcoder