### PR TITLE
autoupdate.version_regex: allow multiple capture groups, splitted by '.'

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -255,7 +255,8 @@ class AppAutoUpdater:
             match = re.match(version_regex, tag)
             if match is None:
                 return None
-            return match.group(1)
+            # Basically: either groupdict if named capture gorups, sorted by names, or groups()
+            return ".".join(dict(sorted(match.groupdict().items())).values() or match.groups())
 
         def version_numbers(tag: str) -> Optional[tuple[int, ...]]:
             filter_keywords = ["start", "rc", "beta", "alpha"]


### PR DESCRIPTION
Yeah so when minetest has version = "1.9.0mt13", "1.9.0mt14", the current code isn't enough to compare versions.

So i had the idea that version_regex could have multiple capture groups,

Here the code allows for named capture groups `(?P<name>.*)` to reorder groups alphabetically.