### PR TITLE
Add DownloadPageAPI to the autoupdater to download from HTML web pages

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -461,7 +461,7 @@ class AppAutoUpdater:
         self, strategy: str, asset: Union[str, dict], infos: dict[str, Any]
     ) -> Optional[tuple[str, Union[str, dict[str, str]], str]]:
         autoupdate = infos.get("autoupdate")
-        upstream = autoupdate.get("upstream", self.main_upstream).strip("/")
+        upstream = autoupdate.get("upstream", self.main_upstream)
         version_re = autoupdate.get("version_regex", None)
         allow_prereleases = autoupdate.get("allow_prereleases", False)
         _, remote_type, revision_type = strategy.split("_")

--- a/tools/autoupdate_app_sources/requirements.txt
+++ b/tools/autoupdate_app_sources/requirements.txt
@@ -2,3 +2,5 @@ requests
 PyGithub
 toml
 tqdm
+beautifulsoup4
+lxml

--- a/tools/autoupdate_app_sources/rest_api.py
+++ b/tools/autoupdate_app_sources/rest_api.py
@@ -15,7 +15,7 @@ class RefType(Enum):
 
 class GithubAPI:
     def __init__(self, upstream: str, auth: Optional[tuple[str, str]] = None):
-        self.upstream = upstream
+        self.upstream = upstream.strip("/")
         self.upstream_repo = upstream.replace("https://github.com/", "").strip("/")
         assert (
             len(self.upstream_repo.split("/")) == 2

--- a/tools/autoupdate_app_sources/rest_api.py
+++ b/tools/autoupdate_app_sources/rest_api.py
@@ -4,6 +4,8 @@ import re
 from enum import Enum
 from typing import Any, Optional
 
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
 import requests
 
 
@@ -206,3 +208,18 @@ class GiteaForgejoAPI:
             )
         else:
             return f"{self.forge_root}/{self.project_path}/releases/tag/{new_ref}"
+
+
+class DownloadPageAPI:
+    def __init__(self, upstream: str) -> None:
+        self.web_page = upstream
+
+    def get_web_page_links(self) -> dict[str, str]:
+        r = requests.get(self.web_page)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, features="lxml")
+
+        return {
+            link.string: urljoin(self.web_page, link.get("href"))
+            for link in soup.find_all('a')
+        }


### PR DESCRIPTION
Tested with Jitsi and this configuration:

```
autoupdate.strategy = "latest_webpage_link"
autoupdate.upstream = "https://download.jitsi.org/stable/"
autoupdate.version_regex = "^jitsi-meet-web_([\\d\\.\\-]*)_all.deb$"
```