### PR TITLE
manifest schema: allow caps for install.*.choices keys

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -187,7 +187,7 @@
                                     "required": [],
                                     "additionalProperties": false,
                                     "patternProperties": {
-                                        "^[a-z][a-z0-9_]*$": {
+                                        "^[a-zA-Z][a-zA-Z0-9_]*$": {
                                             "type": "string"
                                         }
                                     }


### PR DESCRIPTION
Mantis wants caps in its settings, that are replaced in the configuration file.