### PR TITLE
list_builder: just take the app repository's HEAD

### DIFF
--- a/tools/list_builder.py
+++ b/tools/list_builder.py
@@ -197,17 +197,7 @@ def build_app_dict(app, infos):
 
     # If using head, find the most recent meaningful commit in logs
     if infos["revision"] == "HEAD":
-        relevant_files = [
-            "manifest.json",
-            "manifest.toml",
-            "config_panel.toml",
-            "hooks/",
-            "scripts/",
-            "conf/",
-            "sources/",
-        ]
-        relevant_commits = repo.iter_commits(paths=relevant_files, full_history=True, all=True)
-        infos["revision"] = next(relevant_commits).hexsha
+        infos["revision"] = repo.head.commit.hexsha
 
     # Otherwise, validate commit exists
     else:


### PR DESCRIPTION
Let's not scroll down the repository for 'relevant commits' anymore. Nothing is related to the SHA anymore, but to the version number.