### PR TITLE
tag dispatch as deprecated

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -645,6 +645,7 @@ url = "https://github.com/YunoHost-Apps/discourse_ynh"
 
 [dispatch]
 category = "communication"
+antifeatures = [ "deprecated-software" ]
 level = 8
 state = "working"
 subtags = [ "chat" ]


### PR DESCRIPTION
someone asked in the upstream repo nearly a year ago if the project is still maintained
see: https://github.com/khlieng/dispatch/issues/114

as there is no reply, i consider the software as deprecated
