### PR TITLE
deprecated mautrix facebook

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1927,6 +1927,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_discord_ynh"
 
 [mautrix_facebook]
 category = "communication"
+antifeatures = [ "deprecated-software" ]
 level = 6
 potential_alternative_to = [ "Facebook Messenger" ]
 state = "working"


### PR DESCRIPTION
> This bridge is deprecated. [mautrix-meta](https://github.com/mautrix/meta) is recommended instead.

https://github.com/mautrix/facebook