### PR TITLE
use lstrip and rstrip instead of strip to fix some edge case

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -300,7 +300,7 @@ class AppAutoUpdater:
 
     @staticmethod
     def tag_to_int_tuple(tag: str) -> tuple[int, ...]:
-        tag = tag.strip("v").replace("-", ".").strip(".")
+        tag = tag.lstrip("v").replace("-", ".").rstrip(".")
         int_tuple = tag.split(".")
         assert all(i.isdigit() for i in int_tuple), f"Cant convert {tag} to int tuple :/"
         return tuple(int(i) for i in int_tuple)


### PR DESCRIPTION
Discussed with @Salamandar,

The main problem is like this PR:
https://github.com/YunoHost-Apps/lxd-dashboard_ynh/pull/25

where .3.8.0 is considered an higher version than 3.8.0