### PR TITLE
Better handling of version format in relevant_versions()

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -274,7 +274,7 @@ class AppAutoUpdater:
             elif tag.startswith("release-"):
                 t_to_check = tag.split("-", 1)[-1].replace("-", ".")
 
-            if re.match(r"^v?[\d\.]*\-?\d$", t_to_check):
+            if re.match(r"^v?\d+(\.\d+)*(\-\d+)?$", t_to_check):
                 return AppAutoUpdater.tag_to_int_tuple(t_to_check)
             print(f"Ignoring tag {t_to_check}, doesn't look like a version number")
             return None


### PR DESCRIPTION
Follow-up of #2091 

The previous regex allowed things like "v.1.2" and "v...-", use + instead of * and better tokens ordering