### PR TITLE
Fix regex to replace version in manifest

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -480,7 +480,7 @@ class AppAutoUpdater:
         if is_main:
             def repl(m: re.Match) -> str:
                 return m.group(1) + new_version + '~ynh1"'
-            content = re.sub(r"(\s*version\s*=\s*[\"\'])([\d\.]+)(\~ynh\d+[\"\'])", repl, content)
+            content = re.sub(r"(\s*version\s*=\s*[\"\'])([^~\"\']+)(\~ynh\d+[\"\'])", repl, content)
 
         for old, new in replacements:
             content = content.replace(old, new)


### PR DESCRIPTION
This regex is used to find (textually, not via toml parser) where to replace the version number in the Manifest.

Until now it was only supporting version numbers containing dots and digits. I changed that to version numbers containing `anything but ~ and "` to handle version numbers with dashes, or manually written version numbers that might be invalid (if someone litteraly writes `version = "x.y~ynh1"). We don’t actually care about the version number we match against because we just replace it.

