### PR TITLE
feat(readme_generator): don't hardcode the list of languages, extract it from the README templates

### DIFF
--- a/tools/readme_generator/make_readme.py
+++ b/tools/readme_generator/make_readme.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from copy import deepcopy
 
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 
 import toml
 from jinja2 import Environment, FileSystemLoader
@@ -51,7 +51,22 @@ def generate_READMEs(app_path: Path):
 
     env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
 
-    for lang, lang_suffix in [("en", ""), ("fr", "_fr")]:
+    # parse available README template and generate a list in the form of:
+    # > [("en", ""), ("fr", "_fr"), ...]
+    available_langs: List[Tuple[str, str]] = [("en", "")]
+    for README_template in (Path(__file__).parent / "templates").iterdir():
+        # we only want README_{lang}.md.j2 files
+        if README_template.name == "README.md.j2":
+            continue
+
+        if not README_template.name.endswith(".j2") or not README_template.name.startswith("README_"):
+            continue
+
+        language_code = README_template.name.split("_")[1].split(".")[0]
+
+        available_langs.append((language_code, "_" + language_code))
+
+    for lang, lang_suffix in available_langs:
         template = env.get_template(f"README{lang_suffix}.md.j2")
 
         if (app_path / "doc" / f"DESCRIPTION{lang_suffix}.md").exists():


### PR DESCRIPTION
This won't change the existing behavior at all but if suddenly we add a "README_de.md.j2" or any other lang it will be supported.

(thus we should push those README templates on weblate and sync them back in this repo but that's another step)