### PR TITLE
readme-generator: only pick files (no folder) on the root of 'screenshots'

### DIFF
--- a/tools/readme_generator/make_readme.py
+++ b/tools/readme_generator/make_readme.py
@@ -87,9 +87,9 @@ def generate_READMEs(app_path: Path):
             # only pick files (no folder) on the root of 'screenshots'
             for entry in os.scandir(os.path.join(app_path, "doc", "screenshots")):
                 if os.DirEntry.is_file(entry):
-                    screenshots.append(os.path.relpath(entry.path, app_path))
-            if ".gitkeep" in screenshots:
-                screenshots.remove(".gitkeep")
+                    # ignore '.gitkeep' or any file whose name begins with a dot
+                    if not entry.name.startswith("."):
+                        screenshots.append(os.path.relpath(entry.path, app_path))
 
         disclaimer: Optional[str]
         if (app_path / "doc" / f"DISCLAIMER{lang_suffix}.md").exists():

--- a/tools/readme_generator/make_readme.py
+++ b/tools/readme_generator/make_readme.py
@@ -83,11 +83,13 @@ def generate_READMEs(app_path: Path):
 
         screenshots: List[str]
         if (app_path / "doc" / "screenshots").exists():
-            screenshots = os.listdir(os.path.join(app_path, "doc", "screenshots"))
+            screenshots = []
+            # only pick files (no folder) on the root of 'screenshots'
+            for entry in os.scandir(os.path.join(app_path, "doc", "screenshots")):
+                if os.DirEntry.is_file(entry):
+                    screenshots.append(os.path.relpath(entry.path, app_path))
             if ".gitkeep" in screenshots:
                 screenshots.remove(".gitkeep")
-        else:
-            screenshots = []
 
         disclaimer: Optional[str]
         if (app_path / "doc" / f"DISCLAIMER{lang_suffix}.md").exists():

--- a/tools/readme_generator/make_readme.py
+++ b/tools/readme_generator/make_readme.py
@@ -82,8 +82,8 @@ def generate_READMEs(app_path: Path):
             description = None
 
         screenshots: List[str]
+        screenshots = []
         if (app_path / "doc" / "screenshots").exists():
-            screenshots = []
             # only pick files (no folder) on the root of 'screenshots'
             for entry in os.scandir(os.path.join(app_path, "doc", "screenshots")):
                 if os.DirEntry.is_file(entry):

--- a/tools/readme_generator/make_readme.py
+++ b/tools/readme_generator/make_readme.py
@@ -51,6 +51,16 @@ def generate_READMEs(app_path: Path):
 
     env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
 
+    screenshots: List[str]
+    screenshots = []
+    if (app_path / "doc" / "screenshots").exists():
+        # only pick files (no folder) on the root of 'screenshots'
+        for entry in os.scandir(os.path.join(app_path, "doc", "screenshots")):
+            if os.DirEntry.is_file(entry):
+                # ignore '.gitkeep' or any file whose name begins with a dot
+                if not entry.name.startswith("."):
+                    screenshots.append(os.path.relpath(entry.path, app_path))
+
     # parse available README template and generate a list in the form of:
     # > [("en", ""), ("fr", "_fr"), ...]
     available_langs: List[Tuple[str, str]] = [("en", "")]
@@ -80,16 +90,6 @@ def generate_READMEs(app_path: Path):
             description = (app_path / "doc" / "DESCRIPTION.md").read_text()
         else:
             description = None
-
-        screenshots: List[str]
-        screenshots = []
-        if (app_path / "doc" / "screenshots").exists():
-            # only pick files (no folder) on the root of 'screenshots'
-            for entry in os.scandir(os.path.join(app_path, "doc", "screenshots")):
-                if os.DirEntry.is_file(entry):
-                    # ignore '.gitkeep' or any file whose name begins with a dot
-                    if not entry.name.startswith("."):
-                        screenshots.append(os.path.relpath(entry.path, app_path))
 
         disclaimer: Optional[str]
         if (app_path / "doc" / f"DISCLAIMER{lang_suffix}.md").exists():

--- a/tools/readme_generator/templates/README.md.j2
+++ b/tools/readme_generator/templates/README.md.j2
@@ -42,7 +42,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 ## Screenshots
 
 {% for screenshot in screenshots -%}
-    ![Screenshot of {{manifest.name}}](./doc/screenshots/{{screenshot}})
+    ![Screenshot of {{manifest.name}}](./{{screenshot}})
 {% endfor %}
 {% endif -%}
 

--- a/tools/readme_generator/templates/README_fr.md.j2
+++ b/tools/readme_generator/templates/README_fr.md.j2
@@ -28,7 +28,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 ## Captures d’écran
 
 {% for screenshot in screenshots -%}
-    ![Capture d’écran de {{manifest.name}}](./doc/screenshots/{{screenshot}})
+    ![Capture d’écran de {{manifest.name}}](./{{screenshot}})
 {% endfor %}
 {% endif -%}
 


### PR DESCRIPTION
## The problem

if a subfolder exists, it is used as a screenshot file:
`![Screenshot of Some App](./doc/screenshots/subfolder)`

this is obviously wrong

## The solution

- adapt `readme-generator` to only pick actual files (no folder) on the root of the 'screenshots' directory
- also moved the `screenshots` code part to only run it once, since it do not change with language

this also permit to create subfolders to store pictures only used in docs

## PR status

ready to review