### PR TITLE
chores: Upgrade setup-python from v4 to v5 to upgrade nodejs to v20

### DIFF
--- a/.github/workflows/tests_make_readme.yml
+++ b/.github/workflows/tests_make_readme.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up Python 3.9'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: 'pip'


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.