### PR TITLE
add TOML formating using Taplo

### DIFF
--- a/.github/workflows/test_toml.yaml
+++ b/.github/workflows/test_toml.yaml
@@ -1,0 +1,31 @@
+name: Check formatting
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uncenter/setup-taplo@v1
+      - run: taplo fmt
+      - shell: pwsh
+        id: check_files_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff
+          $HasDiff = $diff.Length -gt 0
+          Write-Host "::set-output name=files_changed::$HasDiff"
+      - name: Create Pull Request
+        if: steps.check_files_changed.outputs.files_changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Format TOML with Taplo"
+          commit-message: ":art: Format TOML with Taplo"
+          body: |
+            This pull request uses the [Taplo](https://taplo.tamasfe.dev) formatter.
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+          branch: actions/toml

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,9 @@
+include = [ "antifeatures.toml", "apps.toml", "categories.toml", "graveyard.toml", "taplo.toml" ]
+
+[formatting]
+array_auto_expand = false
+compact_arrays = false
+indent_tables = true
+inline_table_expand = false
+reorder_arrays = true
+reorder_keys = true


### PR DESCRIPTION
- add a configuration file for TOML formating
  - defaults can be seen here: https://taplo.tamasfe.dev/configuration/formatter-options.html
  - the configuration was done to respect current practices
  - automatically sorts alphabetically arrays and keys
- add a github action for auto formating all TOML files