### PR TITLE
logging_sender.py: permit to choose a matrix chan where to send the notification

### DIFF
--- a/tools/appslib/logging_sender.py
+++ b/tools/appslib/logging_sender.py
@@ -10,10 +10,8 @@ def notify(message, channel):
 
     chan_list = ["dev", "apps", "doc"]
 
-    try:
-        any(channel in x for x in chan_list)
-    except False:
-        logging.warning(
+    if not any(channel in x for x in chan_list):
+        logging.error(
             f"Provided chan '{channel}' is not part of the available options ('dev', 'apps', 'doc')."
         )
 

--- a/tools/appslib/logging_sender.py
+++ b/tools/appslib/logging_sender.py
@@ -19,10 +19,13 @@ def notify(message, channel):
         message = message.replace(char, "")
 
     try:
-        subprocess.call(
-            [
+        subprocess.call([
                 "/var/www/webhooks/matrix-commander",
-                "--markdown -m '{message}' -c /var/www/webhooks/credentials.json --store /var/www/webhooks/store --room 'yunohost-{channel}'",
+                "--markdown", 
+                "-m", message, 
+                "-c", "/var/www/webhooks/credentials.json", 
+                "--store", "/var/www/webhooks/store",
+                "--room", f"yunohost-{channel}",
             ],
             stdout=subprocess.DEVNULL,
         )

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -54,11 +54,13 @@ STRATEGIES = [
 
 
 @cache
-def get_github() -> tuple[
-    Optional[tuple[str, str]],
-    Optional[github.Github],
-    Optional[github.InputGitAuthor],
-]:
+def get_github() -> (
+    tuple[
+        Optional[tuple[str, str]],
+        Optional[github.Github],
+        Optional[github.InputGitAuthor],
+    ]
+):
     try:
         github_login = (
             (REPO_APPS_ROOT / ".github_login")
@@ -286,7 +288,6 @@ class AppAutoUpdater:
     def relevant_versions(
         tags: list[str], app_id: str, version_regex: Optional[str]
     ) -> tuple[str, str]:
-
         def apply_version_regex(tag: str) -> Optional[str]:
             # First preprocessing according to the manifest version_regex…
             if version_regex:
@@ -452,8 +453,8 @@ class AppAutoUpdater:
 
         api: Union[GithubAPI, GitlabAPI, GiteaForgejoAPI]
         if remote_type == "github":
-            assert upstream and upstream.startswith(
-                "https://github.com/"
+            assert (
+                upstream and upstream.startswith("https://github.com/")
             ), f"When using strategy {strategy}, having a defined upstream code repo on github.com is required"
             api = GithubAPI(upstream, auth=get_github()[0])
         if remote_type == "gitlab":
@@ -594,7 +595,6 @@ def paste_on_haste(data):
 
 
 class StdoutSwitch:
-
     class DummyFile:
         def __init__(self) -> None:
             self.result = ""
@@ -728,7 +728,7 @@ def main() -> None:
         paste_url = paste_on_haste(paste_message)
         matrix_message += f"\nSee the full log here: {paste_url}"
 
-    appslib.logging_sender.send_to_matrix(matrix_message)
+    appslib.logging_sender.notify(matrix_message, "apps")
     print(paste_message)
 
 


### PR DESCRIPTION
## The problem

- Autoupdater pushes it's notifications on yunohost-dev, where it's irrelevant, this notif is for packagers

## The solution

- Permit to choose a matrix channel where to send the notification, so the tool is more versatile and the notifications are pushed to a chan where they're relevant

took inspiration here: https://github.com/YunoHost/webhooks/blob/master/server.py#L34

## PR status

not tested
ready to review