### PR TITLE
store: fix TOS typo, plural "services"

### DIFF
--- a/store/messages.pot
+++ b/store/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 16:09+0100\n"
+"POT-Creation-Date: 2024-03-17 04:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,11 +21,11 @@ msgstr ""
 msgid "App %(app_id) not found"
 msgstr ""
 
-#: app.py:152
+#: app.py:153
 msgid "You must be logged in to be able to star an app"
 msgstr ""
 
-#: app.py:152 app.py:195 app.py:449 templates/wishlist_add.html:33
+#: app.py:155 app.py:205 app.py:496 templates/wishlist_add.html:33
 msgid ""
 "Note that, due to various abuses, we restricted login on the app store to"
 " 'trust level 1' users.<br/><br/>'Trust level 1' is obtained after "
@@ -34,71 +34,71 @@ msgid ""
 "minutes reading posts."
 msgstr ""
 
-#: app.py:195
+#: app.py:203
 msgid "You must be logged in to submit an app to the wishlist"
 msgstr ""
 
-#: app.py:207
+#: app.py:220
 msgid "Invalid CSRF token, please refresh the page and try again"
 msgstr ""
 
-#: app.py:228
+#: app.py:260
 msgid ""
 "Proposing wishlist additions is limited to once every 15 days per user. "
 "Please try again in a few days."
 msgstr ""
 
-#: app.py:230
+#: app.py:264
 msgid "App name should be at least 3 characters"
 msgstr ""
 
-#: app.py:231
+#: app.py:265
 msgid "App name should be less than 30 characters"
 msgstr ""
 
-#: app.py:234
+#: app.py:268
 msgid "App description should be at least 5 characters"
 msgstr ""
 
-#: app.py:238
+#: app.py:272
 msgid "App description should be less than 100 characters"
 msgstr ""
 
-#: app.py:242
+#: app.py:276
 msgid "Upstream code repo URL should be at least 10 characters"
 msgstr ""
 
-#: app.py:246
+#: app.py:280
 msgid "Upstream code repo URL should be less than 150 characters"
 msgstr ""
 
-#: app.py:250
+#: app.py:284
 msgid "License URL should be at least 10 characters"
 msgstr ""
 
-#: app.py:254
+#: app.py:288
 msgid "License URL should be less than 250 characters"
 msgstr ""
 
-#: app.py:256
+#: app.py:290
 msgid "Website URL should be less than 150 characters"
 msgstr ""
 
-#: app.py:259
+#: app.py:293
 msgid "App name contains special characters"
 msgstr ""
 
-#: app.py:263
+#: app.py:300
 msgid ""
 "Please focus on what the app does, without using marketing, fuzzy terms, "
 "or repeating that the app is 'free' and 'self-hostable'."
 msgstr ""
 
-#: app.py:267
+#: app.py:310
 msgid "No need to repeat the name of the app. Focus on what the app does."
 msgstr ""
 
-#: app.py:301
+#: app.py:344
 #, python-format
 msgid ""
 "An entry with the name %(slug)s already exists in the wishlist, instead, "
@@ -106,7 +106,7 @@ msgid ""
 "interest</a>."
 msgstr ""
 
-#: app.py:325
+#: app.py:369
 #, python-format
 msgid ""
 "Failed to create the pull request to add the app to the wishlist… Maybe "
@@ -114,7 +114,7 @@ msgid ""
 "please report the issue to the YunoHost team."
 msgstr ""
 
-#: app.py:376
+#: app.py:420
 #, python-format
 msgid ""
 "Your proposed app has succesfully been submitted. It must now be "
@@ -122,7 +122,7 @@ msgid ""
 "href='%(url)s'>%(url)s</a>"
 msgstr ""
 
-#: app.py:449
+#: app.py:494
 msgid "Unfortunately, login was denied."
 msgstr ""
 
@@ -279,7 +279,7 @@ msgid "Source"
 msgstr ""
 
 #: templates/base.html:199
-msgid "Terms of Service"
+msgid "Terms of Services"
 msgstr ""
 
 #: templates/catalog.html:75 templates/catalog.html:80

--- a/store/templates/base.html
+++ b/store/templates/base.html
@@ -196,7 +196,7 @@
           <p>
             {{ _("Made with <i class='text-red-500 fa fa-heart-o' aria-label='love'></i> using <a class='text-blue-800' href='https://flask.palletsprojects.com'>Flask</a> and <a class='text-blue-800' href='https://tailwindcss.com/'>TailwindCSS</a>") }}
             • <a class='text-blue-800' href='https://github.com/YunoHost/apps/tree/master/store'><i class='fa fa-code fa-fw' aria-hidden='true'></i> {{ _("Source") }}</a>
-            • <a class='text-blue-800' href='https://forum.yunohost.org/tos'>{{ _("Terms of Service") }}</a>
+            • <a class='text-blue-800' href='https://forum.yunohost.org/tos'>{{ _("Terms of Services") }}</a>
           </p>
         </footer>
   </body>


### PR DESCRIPTION
just a small fix: `Terms of Services` instead of `Terms of Service`