### PR TITLE
Fix logging sender md

### DIFF
--- a/tools/appslib/logging_sender.py
+++ b/tools/appslib/logging_sender.py
@@ -5,7 +5,7 @@ import logging
 import logging.handlers
 
 
-def notify(message: str, channel: str) -> None:
+def notify(message: str, channel: str, markdown: bool = False) -> None:
     print(f"{channel} -> {message}")
 
     chan_list = ["dev", "apps", "doc"]
@@ -18,22 +18,22 @@ def notify(message: str, channel: str) -> None:
     for char in ["'", "`", "!", ";", "$"]:
         message = message.replace(char, "")
 
+    command = [
+        "/var/www/webhooks/matrix-commander",
+        "--message",
+        message,
+        "--credentials",
+        "/var/www/webhooks/credentials.json",
+        "--store",
+        "/var/www/webhooks/store",
+        "--room",
+        f"yunohost-{channel}",
+    ]
+    if markdown:
+        command.append("--markdown")
+
     try:
-        subprocess.call(
-            [
-                "/var/www/webhooks/matrix-commander",
-                "--markdown",
-                "-m",
-                message,
-                "-c",
-                "/var/www/webhooks/credentials.json",
-                "--store",
-                "/var/www/webhooks/store",
-                "--room",
-                f"yunohost-{channel}",
-            ],
-            stdout=subprocess.DEVNULL,
-        )
+        subprocess.call(command, stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         logging.warning(
             f"""Could not send a notification on {channel}.

--- a/tools/appslib/logging_sender.py
+++ b/tools/appslib/logging_sender.py
@@ -5,7 +5,7 @@ import logging
 import logging.handlers
 
 
-def notify(message, channel):
+def notify(message: str, channel: str) -> None:
     print(f"{channel} -> {message}")
 
     chan_list = ["dev", "apps", "doc"]
@@ -43,16 +43,16 @@ def notify(message, channel):
 
 
 class LogSenderHandler(logging.Handler):
-    def __init__(self):
+    def __init__(self) -> None:
         logging.Handler.__init__(self)
         self.is_logging = False
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         msg = f"[Apps tools error] {record.msg}"
         notify(msg, "dev")
 
     @classmethod
-    def add(cls, level=logging.ERROR):
+    def add(cls, level: int = logging.ERROR) -> None:
         if not logging.getLogger().handlers:
             logging.basicConfig()
 
@@ -63,6 +63,6 @@ class LogSenderHandler(logging.Handler):
         logging.getLogger().handlers.append(handler)
 
 
-def enable():
+def enable() -> None:
     """Enables the LogSenderHandler"""
     LogSenderHandler.add(logging.ERROR)

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -693,7 +693,7 @@ def main() -> None:
                 apps_failed[app] = current_version, main_version  # actually stores logs
 
     paste_message = ""
-    matrix_message = "Autoupdater just ran, here are the results:"
+    matrix_message = "Autoupdater just ran, here are the results:\n"
     if apps_already:
         paste_message += f"\n{'=' * 80}\nApps already with an update PR:"
         matrix_message += f"\n- {len(apps_already)} pending update PRs"
@@ -726,7 +726,7 @@ def main() -> None:
         paste_url = paste_on_haste(paste_message)
         matrix_message += f"\nSee the full log here: {paste_url}"
 
-    appslib.logging_sender.notify(matrix_message, "apps")
+    appslib.logging_sender.notify(matrix_message, "apps", markdown=True)
     print(paste_message)
 
 


### PR DESCRIPTION
Sometimes messages aren't markdown (e.g backtraces, etc). So disabling markdown formatting by default.

In autoupdater, adding a second line break between the "title" and the list of apps.