### PR TITLE
readme_generator: remove '**' from some string to facilitate translation (and not confusing translators)

### DIFF
--- a/tools/readme_generator/templates/README.md.j2
+++ b/tools/readme_generator/templates/README.md.j2
@@ -32,11 +32,11 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 ## {{ _("Overview") }}
 
 {% if description %}{{description}}{% else %}{{manifest.description[lang]}}{% endif %}
-{{ _("**Shipped version:**") }} {% if upstream.version %}{{upstream.version}}{% else %}{{manifest.version}}
+**{{ _("Shipped version:") }}** {% if upstream.version %}{{upstream.version}}{% else %}{{manifest.version}}
 {% endif -%}
 
 {% if upstream.demo %}
-{{ _("**Demo:**") }} <{{upstream.demo}}>
+**{{ _("Demo:") }}** <{{upstream.demo}}>
 {% endif -%}
 
 {% if screenshots %}
@@ -79,7 +79,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 {{ _("Please send your pull request to the [testing branch](%(testing_branch_url)s)")|format(testing_branch_url="https://github.com/YunoHost-Apps/" + manifest.id + "_ynh/tree/testing") }},
 
 
-{{ _("To try the testing branch, please proceed like that.") }}
+{{ _("To try the testing branch, please proceed like that:") }}
 
 ```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing --debug

--- a/tools/readme_generator/tests/README.md
+++ b/tools/readme_generator/tests/README.md
@@ -50,7 +50,7 @@ Please note that this package uses the ["i'm so tired" software license 1.0](htt
 Please send your pull request to the [testing branch](https://github.com/YunoHost-Apps/gotosocial_ynh/tree/testing),
 
 
-To try the testing branch, please proceed like that.
+To try the testing branch, please proceed like that:
 
 ```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/gotosocial_ynh/tree/testing --debug


### PR DESCRIPTION
no need to put the `**` in the translatable strings