### PR TITLE
autoupdater: fix a break line in the matrix message

### DIFF
--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -718,7 +718,7 @@ def main() -> None:
 
     if apps_failed:
         paste_message += f"\n{'=' * 80}\nApps failed:"
-        matrix_message += f"\n- {len(apps_failed)} failed apps updates: {', '.join(str(app) for app in apps_failed.keys())}"
+        matrix_message += f"\n- {len(apps_failed)} failed apps updates: {', '.join(str(app) for app in apps_failed.keys())}\n"
     for app, logs in apps_failed.items():
         paste_message += f"\n{'='*40}\n{app}\n{'-'*40}\n{logs[0]}\n{logs[1]}\n\n"
 


### PR DESCRIPTION
following https://github.com/YunoHost/apps/pull/2173

> Autoupdater just ran, here are the results:
> 
>     70 pending update PRs
>     7 new apps PRs
>     6 failed apps updates: dokuwiki, elasticsearch8, focalboard, framaforms, tvheadend, vikunja See the full log here: http://paste.yunohost.org/raw/ohexifoseg

the `See the full log here:` is right after the failed line when it should be below