### PR TITLE
store: edit 'Anti-features' in 'Antifeatures'

### DIFF
--- a/store/messages.pot
+++ b/store/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-22 04:59+0100\n"
+"POT-Creation-Date: 2024-04-01 00:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -202,7 +202,7 @@ msgid "Important infos before installing"
 msgstr ""
 
 #: templates/app.html:124
-msgid "Anti-features"
+msgid "Antifeatures"
 msgstr ""
 
 #: templates/app.html:125

--- a/store/templates/app.html
+++ b/store/templates/app.html
@@ -121,7 +121,7 @@
     {% endif %}
 
     {% if infos["antifeatures"] %}
-    <h2 class="inline-block text-xl mb-2 font-semibold">{{ _("Anti-features") }}</h2>
+    <h2 class="inline-block text-xl mb-2 font-semibold">{{ _("Antifeatures") }}</h2>
     <p class="inline-block text-sm">{{ _("(This app has features you may not like)") }}</p>
     <div class="my-3 rounded-md bg-red-100 text-red-800 px-5 py-2">
         <ul>


### PR DESCRIPTION
> YunoHost uses both `anti-features` and `antifeatures`. Maybe they could be standardised.
> @xabirequejo 

i digged a bit and only the app store uses `anti-features`, so i edit it to align it with the rest of the project