### PR TITLE
wishlist: remove some deprecated softwares

### DIFF
--- a/wishlist.toml
+++ b/wishlist.toml
@@ -1039,6 +1039,13 @@ upstream = "https://github.com/locomotivecms/engine"
 website = "https://www.locomotivecms.com/"
 added_date = 1695656621  # 2023/09/25
 
+[logitech-media-server]
+name = "Logitech Media Server"
+description = "A streaming audio server (formerly SlimServer, SqueezeCenter and Squeezebox Server)"
+upstream = "http://mysqueezebox.com/download"
+website = "https://en.wikipedia.org/wiki/Logitech_Media_Server"
+added_date = 1695656621  # 2023/09/25
+
 [loomio]
 name = "Loomio"
 description = "A collaborative decision making tool"

--- a/wishlist.toml
+++ b/wishlist.toml
@@ -1118,13 +1118,6 @@ website = "https://pymedusa.com/"
 draft = "https://github.com/YunoHost-Apps/medusa_ynh"
 added_date = 1695656621  # 2023/09/25
 
-[megaglest]
-name = "Megaglest"
-description = "realtime stategy game"
-upstream = "https://megaglest.org/linux-packages.html"
-website = "https://megaglest.org/"
-added_date = 1695656621  # 2023/09/25
-
 [meshery]
 name = "Meshery"
 description = "Cloudnative solution to bind multiple Service-Meshes together, not only K8s"

--- a/wishlist.toml
+++ b/wishlist.toml
@@ -237,13 +237,6 @@ upstream = "https://gitlab.com/cactus-comments"
 website = "https://cactus.chat/"
 added_date = 1695656621  # 2023/09/25
 
-[cagette]
-name = "Cagette"
-description = "A marketplace for local farmers and producers"
-upstream = "https://github.com/CagetteNet/cagette"
-website = "https://www.cagette.net/"
-added_date = 1695656621  # 2023/09/25
-
 [cal-com]
 name = "Cal.com"
 description = "Formerly Calendso. Volunteer shift management and meeting scheduling. Alternative to Calendly."
@@ -1046,13 +1039,6 @@ upstream = "https://github.com/locomotivecms/engine"
 website = "https://www.locomotivecms.com/"
 added_date = 1695656621  # 2023/09/25
 
-[logitech-media-server]
-name = "Logitech Media Server"
-description = "A streaming audio server (formerly SlimServer, SqueezeCenter and Squeezebox Server)"
-upstream = "http://mysqueezebox.com/download"
-website = "https://en.wikipedia.org/wiki/Logitech_Media_Server"
-added_date = 1695656621  # 2023/09/25
-
 [loomio]
 name = "Loomio"
 description = "A collaborative decision making tool"
@@ -1591,13 +1577,6 @@ upstream = "https://github.com/bestpractical/rt"
 website = "https://bestpractical.com"
 added_date = 1695656621  # 2023/09/25
 
-[restya]
-name = "Restya"
-description = "Trello like kanban board. Based on Restya platform."
-upstream = "https://github.com/RestyaPlatform/board/"
-website = "https://restya.com"
-added_date = 1695656621  # 2023/09/25
-
 [retroshare]
 name = "Retroshare"
 description = "Friend-2-Friend, secure decentralised communication platform."
@@ -1655,13 +1634,6 @@ upstream = "https://git.sr.ht/~edwardloveall/scribe"
 website = "https://scribe.rip/"
 draft = "https://github.com/YunoHost-Apps/scribe_ynh"
 added_date = 1695656621  # 2023/09/25
-
-[script-server]
-name = "script-server"
-description = "Web UI for your scripts with execution management"
-upstream = "https://github.com/bugy/script-server"
-website = "https://script-server.net/"
-added_date = 1707934203  # 2024/02/14
 
 [semantic-mediawiki]
 name = "Semantic MediaWiki"
@@ -2052,13 +2024,6 @@ name = "Whoogle"
 description = "A metasearch engine"
 upstream = "https://github.com/benbusby/whoogle-search"
 website = ""
-added_date = 1695656621  # 2023/09/25
-
-[wikiless]
-name = "Wikiless"
-description = "An alternative Wikipedia front-end focused on privacy."
-upstream = "https://codeberg.org/orenom/wikiless"
-website = "https://wikiless.org/"
 added_date = 1695656621  # 2023/09/25
 
 [wikisuite]


### PR DESCRIPTION
deprecated:

- restya: seams dead, see https://github.com/RestyaPlatform/board/issues/4426
- script-server, website is gone, no commit for 4 years, seams dead: https://github.com/bugy/script-server
- cagette: repo is gone, now a proprietary software, see: https://wiki.cagette.net/devfaq
- wikiless: website and repo are gone

not self-hostable:

- megaglest: it's a graphical computer game
