### PR TITLE
Handle non existing executable for logging_sender.py

### DIFF
--- a/tools/appslib/logging_sender.py
+++ b/tools/appslib/logging_sender.py
@@ -34,6 +34,8 @@ def notify(message: str, channel: str, markdown: bool = False) -> None:
 
     try:
         subprocess.call(command, stdout=subprocess.DEVNULL)
+    except FileNotFoundError:
+        logging.warning("The logging sender tool /var/www/webhooks/matrix-commander does not exist.")
     except subprocess.CalledProcessError as e:
         logging.warning(
             f"""Could not send a notification on {channel}.


### PR DESCRIPTION
When running locally the autoupdater, we can run into "matrix-commander: no such file or directory" even though we don't care about that. Just warn, no error.