### PR TITLE
Depreciate Yunomonitor

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -4287,6 +4287,8 @@ url = "https://github.com/YunoHost-Apps/yourls_ynh"
 
 [yunomonitor]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "deprecated-software" ]
+deprecated_date = 1672947186 # 2023/01/05
 category = "system_tools"
 level = 8
 state = "working"


### PR DESCRIPTION
I am the author of YunoMonitor, it's deprecated, it has been created a long time agor before the YunoHost Diagnosis tools, all the email part of yunomonitor has been imported inside YunoHost diagnosis, i don't never use it (and don't maintain it).