### PR TITLE
Mark OS.js as deprecated

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -4290,8 +4290,8 @@ url = "https://github.com/YunoHost-Apps/yourls_ynh"
 [yunomonitor]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
-deprecated_date = 1672947186 # 2023/01/05
 category = "system_tools"
+deprecated_date = 1672947186 # 2023/01/05
 level = 8
 state = "working"
 subtags = [ "monitoring" ]

--- a/apps.toml
+++ b/apps.toml
@@ -2724,7 +2724,9 @@ url = "https://github.com/YunoHost-Apps/osada_ynh"
 
 [osjs]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "deprecated-software" ]
 category = "wat"
+deprecated_date = 1712777448 # 2024/04/10
 level = 8
 state = "working"
 url = "https://github.com/YunoHost-Apps/osjs_ynh"


### PR DESCRIPTION
Install failing with Python 3.11+, will most likely never be fixed.