### PR TITLE
fix a typo for 'not-totally-free-upstream/package'

### DIFF
--- a/antifeatures.toml
+++ b/antifeatures.toml
@@ -133,7 +133,7 @@ title.fr = "Logiciel en version alpha "
 title.it = "Software in versione alpha"
 
 [not-totally-free-upstream]
-description.en = "The packaged app is under an overall free licence, but with clauses that restrict its use."
+description.en = "The packaged app is under an overall free license, but with clauses that may restrict its use."
 description.eu = "Aplikazioak lizentzia librea du orokorrean, baina bere erabilera mugatzen duten klausulekin."
 description.fr = "L'application packagée est sous une licence globalement libre, mais avec des clauses qui pourraient restreindre son utilisation."
 description.it = "Quest’applicazione è protetta da licenza generalmente libera, ma con delle clausole che potrebbero limitare il suo utilizzo."
@@ -144,7 +144,7 @@ title.fr = "Application sous licence libre restreinte "
 title.it = "Applicazione con licenza parzialmente libera"
 
 [not-totally-free-package]
-description.en = "The YunoHost package of this app is under an overall free licence, but with clauses that restrict its use."
+description.en = "The YunoHost package of this app is under an overall free license, but with clauses that may restrict its use."
 description.eu = "Aplikazio honen YunoHost paketeak lizentzia librea du orokorrean, baina bere erabilera mugatzen duten klausulekin."
 description.fr = "Le package YunoHost de cette application est sous une licence globalement libre, mais avec des clauses qui pourraient restreindre son utilisation."
 icon = "archive"

--- a/tools/readme_generator/tests/README.md
+++ b/tools/readme_generator/tests/README.md
@@ -35,7 +35,7 @@ Please note that this package uses the ["i'm so tired" software license 1.0](htt
 ## :red_circle: Antifeatures
 
 - **Alpha software**: Early development stage. May contain changing or unstable features, bugs, and security vulnerability.
-- **Not totally free package**: The YunoHost package of this app is under an overall free licence, but with clauses that restrict its use.
+- **Not totally free package**: The YunoHost package of this app is under an overall free license, but with clauses that may restrict its use.
 
 ## Documentation and resources
 


### PR DESCRIPTION
in english, the correct word is "license", not "licence" :'3