### PR TITLE
Add link to hosted YoloGen

### DIFF
--- a/tools/app_generator/README.md
+++ b/tools/app_generator/README.md
@@ -2,6 +2,8 @@
 
 This is a Flask app generating a draft .zip of a YunoHost application after filling a form
 
+Official instance: https://appgenerator.yunohost.org/
+
 ## Developement
 
 ```bash


### PR DESCRIPTION
Why was it missing from README in the first place:

https://appgenerator.yunohost.org/