### PR TITLE
Drop legacy catalog v2 API

### DIFF
--- a/tools/list_builder.py
+++ b/tools/list_builder.py
@@ -84,26 +84,6 @@ def build_base_catalog(nproc: int):
     return result_dict
 
 
-def write_catalog_v2(base_catalog, target_dir: Path) -> None:
-    result_dict_with_manifest_v1 = copy.deepcopy(base_catalog)
-    result_dict_with_manifest_v1 = {
-        name: infos
-        for name, infos in result_dict_with_manifest_v1.items()
-        if float(str(infos["manifest"].get("packaging_format", "")).strip() or "0") < 2
-    }
-    full_catalog = {
-        "apps": result_dict_with_manifest_v1,
-        "categories": categories_list(),
-        "antifeatures": antifeatures_list(),
-    }
-
-    target_file = target_dir / "apps.json"
-    target_file.parent.mkdir(parents=True, exist_ok=True)
-    target_file.open("w", encoding="utf-8").write(
-        json.dumps(full_catalog, sort_keys=True)
-    )
-
-
 def write_catalog_v3(base_catalog, target_dir: Path) -> None:
     result_dict_with_manifest_v2 = copy.deepcopy(base_catalog)
     for app in result_dict_with_manifest_v2.values():
@@ -287,7 +267,6 @@ def main() -> None:
     catalog = build_base_catalog(args.jobs)
 
     print(f"Writing the catalogs to {args.target_dir}...")
-    write_catalog_v2(catalog, args.target_dir / "v2")
     write_catalog_v3(catalog, args.target_dir / "v3")
     write_catalog_doc(catalog, args.target_dir / "doc_catalog")
     print("Done!")


### PR DESCRIPTION
The v2 catalog is super old and is almost empty because it only lists apps from the packaging v1 era : https://app.yunohost.org/default/v2/apps.json