### PR TITLE
move rainloop to graveyard

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3281,17 +3281,6 @@ state = "notworking"
 subtags = [ "calendar", "contacts" ]
 url = "https://github.com/YunoHost-Apps/radicale_ynh"
 
-[rainloop]
-added_date = 1674232499 # 2023/01/20
-antifeatures = [ "bad-security-reputation", "deprecated-software", "replaced-by-another-app" ]
-category = "communication"
-deprecated_date = 1676378222 # 2023/02/14
-level = 6
-potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
-state = "working"
-subtags = [ "email" ]
-url = "https://github.com/YunoHost-Apps/rainloop_ynh"
-
 [rallly]
 added_date = 1708020558 # 2024/02/15
 category = "productivity_and_management"

--- a/graveyard.toml
+++ b/graveyard.toml
@@ -253,6 +253,15 @@ category = "system_tools"
 killed_date = 1703600553 # 2023/12/26
 url = "https://github.com/YunoHost-Apps/portainer_ynh"
 
+[rainloop]
+added_date = 1674232499 # 2023/01/20
+antifeatures = [ "bad-security-reputation", "deprecated-software", "replaced-by-another-app" ]
+category = "communication"
+deprecated_date = 1676378222 # 2023/02/14
+potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
+subtags = [ "email" ]
+url = "https://github.com/YunoHost-Apps/rainloop_ynh"
+
 [reel2bits]
 added_date = 1554588215 # 2019/04/07
 category = "social_media"


### PR DESCRIPTION
Rainloop is deprecated and replaced by snappymail for more than a year now, so i think it’s time to move it to the graveyard

Rip in peas smol mail client