### PR TITLE
tools: refactor github credentials location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,14 +11,8 @@ __pycache__/
 .mypy_cache/
 
 # Github authentication files
-/.github_*
+/tools/.github_*
 
 # yunohost specific cache/output dirs
 .apps_cache
 builds*
-
-tools/bot-repo-cleanup/.github_token
-tools/autoupdater-upgrader/.*
-
-tools/autopatches/login
-tools/autopatches/token

--- a/tools/autopatches/autopatch.py
+++ b/tools/autopatches/autopatch.py
@@ -4,8 +4,11 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import requests
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
 
 catalog = requests.get(
     "https://raw.githubusercontent.com/YunoHost/apps/master/apps.json"
@@ -15,8 +18,8 @@ my_env = os.environ.copy()
 my_env["GIT_TERMINAL_PROMPT"] = "0"
 os.makedirs(".apps_cache", exist_ok=True)
 
-login = open("login").read().strip()
-token = open("token").read().strip()
+login = (TOOLS_DIR / ".github_login").open("r", encoding="utf-8").read().strip()
+token = (TOOLS_DIR / ".github_token").open("r", encoding="utf-8").read().strip()
 github_api = "https://api.github.com"
 
 

--- a/tools/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/tools/autoupdate_app_sources/autoupdate_app_sources.py
@@ -60,19 +60,19 @@ def get_github() -> tuple[
 ]:
     try:
         github_login = (
-            (REPO_APPS_ROOT / ".github_login")
+            (REPO_APPS_ROOT / "tools" / ".github_login")
             .open("r", encoding="utf-8")
             .read()
             .strip()
         )
         github_token = (
-            (REPO_APPS_ROOT / ".github_token")
+            (REPO_APPS_ROOT / "tools" / ".github_token")
             .open("r", encoding="utf-8")
             .read()
             .strip()
         )
         github_email = (
-            (REPO_APPS_ROOT / ".github_email")
+            (REPO_APPS_ROOT / "tools" / ".github_email")
             .open("r", encoding="utf-8")
             .read()
             .strip()

--- a/tools/bot-repo-cleanup/cleanup.py
+++ b/tools/bot-repo-cleanup/cleanup.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
+
 # Obtained with `pip install PyGithub`, better within a venv
 from github import Github
 from github.Workflow import Workflow
 
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+
 # API token for yunohost-bot, with "delete_repo" right
-g = Github(open(".github_token").read().strip())
+
+token = (TOOLS_DIR / ".github_token").open("r", encoding="utf-8").read().strip()
+g = Github(token)
 u = g.get_user("yunohost-bot")
 
 # Let's build a minimalistic summary table

--- a/tools/readme_generator/regen_readme_in_batch.py
+++ b/tools/readme_generator/regen_readme_in_batch.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import time
 import json
 import os
@@ -9,10 +11,11 @@ import requests
 from make_readme import generate_READMEs
 from pathlib import Path
 
-github_webhook_secret = open("github_webhook_secret", "r").read().strip()
+TOOLS_DIR = Path(__file__).resolve().parent.parent
 
-login = open("login").read().strip()
-token = open("token").read().strip()
+secret = (TOOLS_DIR / ".github_webhook_secret").open("r", encoding="utf-8").read().strip()
+login = (TOOLS_DIR / ".github_login").open("r", encoding="utf-8").read().strip()
+token = (TOOLS_DIR / ".github_token").open("r", encoding="utf-8").read().strip()
 
 my_env = os.environ.copy()
 my_env["GIT_TERMINAL_PROMPT"] = "0"

--- a/tools/readme_generator/webhook.py
+++ b/tools/readme_generator/webhook.py
@@ -11,22 +11,23 @@ from sanic import HTTPResponse, Request, Sanic, response
 
 from make_readme import generate_READMEs
 
-app = Sanic(__name__)
+TOOLS_DIR = Path(__file__).resolve().parent.parent
 
+app = Sanic(__name__)
 
 @cache
 def github_webhook_secret() -> str:
-    return Path("github_webhook_secret").resolve().open(encoding="utf-8").read().strip()
+    return (TOOLS_DIR / ".github_webhook_secret").open("r", encoding="utf-8").read().strip()
 
 
 @cache
 def github_login() -> str:
-    return Path("login").resolve().open(encoding="utf-8").read().strip()
+    return (TOOLS_DIR / ".github_login").open("r", encoding="utf-8").read().strip()
 
 
 @cache
 def github_token() -> str:
-    return Path("token").resolve().open(encoding="utf-8").read().strip()
+    return (TOOLS_DIR / ".github_token").open("r", encoding="utf-8").read().strip()
 
 
 @app.route("/github", methods=["GET"])

--- a/tools/update_app_levels/update_app_levels.py
+++ b/tools/update_app_levels/update_app_levels.py
@@ -22,10 +22,11 @@ APPS_REPO = "YunoHost/apps"
 CI_RESULTS_URL = "https://ci-apps.yunohost.org/ci/api/results"
 
 REPO_APPS_ROOT = Path(Repo(__file__, search_parent_directories=True).working_dir)
+TOOLS_DIR = REPO_APPS_ROOT / "tools"
 
 
 def github_token() -> Optional[str]:
-    github_token_path = REPO_APPS_ROOT / ".github_token"
+    github_token_path = TOOLS_DIR / ".github_token"
     if github_token_path.exists():
         return github_token_path.open("r", encoding="utf-8").read().strip()
     return None


### PR DESCRIPTION
Tools were reading github creds from all over the place. They now all read `/tools/.github_{login,token,webhook_secret}`.

That will ease the transition to a unified tools codebase.