### PR TITLE
add "package-not-maintained" antifeature to pihole

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3015,6 +3015,7 @@ url = "https://github.com/YunoHost-Apps/pico_ynh"
 
 [pihole]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "system_tools"
 level = 8
 state = "working"


### PR DESCRIPTION
the pihole package seems unmaintained for a long time and received only basic maintenance and packaging v2 conversion

it also have serious issues:
- it doesn't work out of the box and that's undocumented (and there's nobody to test the fix and accept it): https://github.com/YunoHost-Apps/pihole_ynh/pull/99
  - and it shouldn't be listening in on a public IP either without warning the user what's at stake: cf https://github.com/YunoHost-Apps/adguardhome_ynh/blob/master/doc/ADMIN.md#bind-to-public-ip-addresses
- the package is entirely disabling dnsmasq, and without any warning: https://github.com/YunoHost-Apps/pihole_ynh/issues/121

for me, it deserves to be maintained again by someone who will devote time and care to it
or not recommended for installation due the issues I listed above and its chronic (and maybe critical) lack of maintenance