### PR TITLE
Update apps.toml for packages not maintained

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -448,6 +448,7 @@ url = "https://github.com/YunoHost-Apps/cinny_ynh"
 
 [civicrm_drupal7]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -471,6 +472,7 @@ url = "https://github.com/YunoHost-Apps/cloudlog_ynh"
 
 [cockpit]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "system_tools"
 level = 6
 state = "working"
@@ -548,6 +550,7 @@ url = "https://github.com/YunoHost-Apps/conduit_ynh"
 
 [converse]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "communication"
 level = 6
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -566,6 +569,7 @@ url = "https://github.com/YunoHost-Apps/cops_ynh"
 
 [coturn]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "system_tools"
 level = 8
 state = "working"
@@ -574,6 +578,7 @@ url = "https://github.com/YunoHost-Apps/coturn_ynh"
 
 [couchdb]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "system_tools"
 level = 6
 state = "working"
@@ -610,6 +615,7 @@ url = "https://github.com/YunoHost-Apps/crabfit_ynh"
 
 [cryptpad]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "office"
 level = 8
 potential_alternative_to = [ "Google Docs" ]
@@ -666,6 +672,7 @@ url = "https://github.com/YunoHost-Apps/decidim_ynh"
 
 [deluge]
 added_date = 1691487217 # 2023/08/08
+antifeatures = [ "package-not-maintained" ]
 category = "multimedia"
 level = 7
 potential_alternative_to = [ "µTorrent" ]
@@ -1043,6 +1050,7 @@ url = "https://github.com/YunoHost-Apps/etherpad_ynh"
 
 [etherpad_mypads]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "office"
 level = 6
 potential_alternative_to = [ "G Suite", "Google Docs", "Microsoft Office", "Microsoft Word", "Office 365" ]
@@ -1078,6 +1086,7 @@ url = "https://github.com/YunoHost-Apps/facette_ynh"
 
 [facilmap]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1152,6 +1161,7 @@ url = "https://github.com/Yunohost-Apps/fittrackee_ynh"
 
 [flarum]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "communication"
 level = 8
 potential_alternative_to = [ "Invision Community", "XenForo", "vBulletin" ]

--- a/apps.toml
+++ b/apps.toml
@@ -148,7 +148,6 @@ url = "https://github.com/YunoHost-Apps/anarchism_ynh"
 
 [archivebox]
 added_date = 1674232499 # 2023/01/20
-antifeatures = [ "package-not-maintained" ]
 category = "small_utilities"
 level = 8
 state = "working"

--- a/apps.toml
+++ b/apps.toml
@@ -142,6 +142,7 @@ url = "https://github.com/YunoHost-Apps/anarchism_ynh"
 
 [archivebox]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "small_utilities"
 level = 8
 state = "working"
@@ -179,6 +180,7 @@ url = "https://github.com/YunoHost-Apps/autobrr_ynh"
 
 [automad]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "publishing"
 level = 8
 state = "working"
@@ -226,6 +228,7 @@ url = "https://github.com/YunoHost-Apps/biboumi_ynh"
 
 [bicbucstriim]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "reading"
 level = 7
 state = "working"
@@ -243,6 +246,7 @@ url = "https://github.com/YunoHost-Apps/blogotext_ynh"
 
 [bludit]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "publishing"
 level = 8
 state = "working"
@@ -386,6 +390,7 @@ url = "https://github.com/YunoHost-Apps/cheky_ynh"
 
 [chitchatter]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "communication"
 level = 8
 state = "working"
@@ -2145,6 +2150,7 @@ url = "https://github.com/YunoHost-Apps/lxd-dashboard_ynh"
 
 [lychee]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "multimedia"
 level = 6
 potential_alternative_to = [ "Flickr", "Google Photos" ]
@@ -3034,6 +3040,7 @@ url = "https://github.com/YunoHost-Apps/piped_ynh"
 
 [piwigo]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Google Photos", "Keepeek", "Koken", "Orkis Ajaris", "Orphéa" ]


### PR DESCRIPTION
Looking for feedback on my current selection. I am not quite certain what the official yunohost maintainer definition of "package not maintained" is, so please correct me if I am mistaken, and please feel free to suggest edits.

I am generally looking for packages unmaintained in 3 months, with a more recent upstream update existing, or nonfunctioning due to a lack of maintainence. If an upstream has recent commits, but no recent releases since the yunohost package was last updated, then the ynh package is in good standing by my metrics.

Developed but unusable (recent development, but broken)
Discourse
Lychee

Questionable:
Grafana? (minimally maintained, not up to date, but last commit only 1 mo ago)
bicbucstriim (updated 1 mo ago to a version that's 11 mo old) 1.6.5. vs 3.3.0
calibre-web - very strange versioning on yunohost. version 96.21 vs 6.21? typo?
chitchatter -- looks very underdeveloped on ynh, 6 mo since last ynh push w/ active upstream development, no releases. 
chtickynotes - no upstream? - remove upstream line if there is no upstream in manifest.toml.
Borg - no upstream? Upstream exists, https://github.com/borgbackup/borg



Abantecart: no upstream updates in 10 mo, no ynh updates in 7 mo
Adminer:  no upstream updates in 3 years, no ynh updates in 7 mo
AgenDav: no upstream 2 years, no ynh 5 mo
beehive: no upstream 3 years, no ynh 3 mo
biboumi: no upstream 2 years, no ynh 5 mo
blogotext: no upstream 5 years, no ynh 3 mo

I went through app list up to Cinny. Will continue when I have more free time.