### PR TITLE
Move matrix-puppet-discord to graveyard

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2231,17 +2231,6 @@ state = "working"
 subtags = [ "chat" ]
 url = "https://github.com/YunoHost-Apps/matrix-appservice-irc_ynh"
 
-[matrix-puppet-discord]
-added_date = 1674232499 # 2023/01/20
-antifeatures = [ "deprecated-software" ]
-category = "communication"
-deprecated_date = 1711055457 # 2024/03/21
-level = 6
-potential_alternative_to = [ "Discord" ]
-state = "working"
-subtags = [ "chat" ]
-url = "https://github.com/YunoHost-Apps/matrix-puppet-discord_ynh"
-
 [matterbridge]
 added_date = 1674232499 # 2023/01/20
 category = "communication"

--- a/graveyard.toml
+++ b/graveyard.toml
@@ -186,6 +186,16 @@ potential_alternative_to = [ "Google Groups" ]
 subtags = [ "email" ]
 url = "https://github.com/yunohost-apps/mailman_ynh"
 
+[matrix-puppet-discord]
+added_date = 1674232499 # 2023/01/20
+antifeatures = [ "deprecated-software" ]
+category = "communication"
+deprecated_date = 1711055457 # 2024/03/21
+level = 6
+potential_alternative_to = [ "Discord" ]
+subtags = [ "chat" ]
+url = "https://github.com/YunoHost-Apps/matrix-puppet-discord_ynh"
+
 [mediadrop]
 added_date = 1554588215 # 2019/04/07
 category = "multimedia"


### PR DESCRIPTION
It’s a long time legacy and incompatible with newer synapse versions.

Replacements found at https://matrix.org/ecosystem/bridges/discord/ .