### PR TITLE
add "package-not-maintained" antifeature to technitium package

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3884,6 +3884,7 @@ url = "https://github.com/YunoHost-Apps/teampass_ynh"
 
 [technitium-dns]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "package-not-maintained" ]
 category = "system_tools"
 level = 6
 state = "working"


### PR DESCRIPTION
the package is outdated by 9 versions and almost one year

current upstream release: 12.1
current packaged version: 11.3

cf the changelog for the release dates: https://github.com/TechnitiumSoftware/DnsServer/blob/HEAD/CHANGELOG.md#version-113