### PR TITLE
README: change url of CI level badge to ci-apps.yunohost.org

### DIFF
--- a/tools/readme_generator/templates/README.md.j2
+++ b/tools/readme_generator/templates/README.md.j2
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.") }}
 
 # {{ _("%(application_name)s for YunoHost")|format(application_name=manifest.name) }}
 
-[![{{ _("Integration level") }}](https://dash.yunohost.org/integration/{{manifest.id}}.svg)](https://dash.yunohost.org/appci/app/{{manifest.id}}) ![{{ _("Working status") }}](https://ci-apps.yunohost.org/ci/badges/{{manifest.id}}.status.svg) ![{{ _("Maintenance status") }}](https://ci-apps.yunohost.org/ci/badges/{{manifest.id}}.maintain.svg)
+[![{{ _("Integration level") }}](https://dash.yunohost.org/integration/{{manifest.id}}.svg)](https://ci-apps.yunohost.org/ci/apps/{{manifest.id}}/) ![{{ _("Working status") }}](https://ci-apps.yunohost.org/ci/badges/{{manifest.id}}.status.svg) ![{{ _("Maintenance status") }}](https://ci-apps.yunohost.org/ci/badges/{{manifest.id}}.maintain.svg)
 
 [![{{ _("Install %(application_name)s with YunoHost")|format(application_name=manifest.name) }}](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app={{manifest.id}})
 

--- a/tools/readme_generator/tests/README.md
+++ b/tools/readme_generator/tests/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # GoToSocial for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Working status](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Integration level](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Working status](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Install GoToSocial with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 


### PR DESCRIPTION
The old url was redirecting to the main dash… not pretty.
I fixed this by a redirect on samurai, but it would be nice to fix in the readme directly ;)