### PR TITLE
Add Hydroxide to wishlist

### DIFF
--- a/wishlist.toml
+++ b/wishlist.toml
@@ -828,6 +828,11 @@ upstream = "https://github.com/heyform/heyform"
 website = "https://heyform.net"
 added_date = 1713542406  # 2024/04/19
 
+[hydroxide]
+name = "Hydroxide"
+description = "A third party, open-source Proton Mail CardDAV, IMAP and SMTP bridge."
+upstream = "https://github.com/emersion/hydroxide"
+
 [histopad]
 name = "HistoPad"
 description = "Log pads (etherpad) and archiving them in a git repository"


### PR DESCRIPTION
## Add Hydroxide to wishlist

Proposed by **tommi**

Upstream repo: https://github.com/emersion/hydroxide
License: https://github.com/emersion/hydroxide/blob/master/LICENSE
Description: A third party, open-source Proton Mail CardDAV, IMAP and SMTP bridge.

- [ ] Confirm app is self-hostable and generally makes sense to possibly integrate in YunoHost
- [ ] Confirm app's license is opensource/free software (or not-totally-free-upstream, case by case TBD)
- [ ] Description describes clearly and concisely what the app is/does