### PR TITLE
Rename endi in caerp

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -339,6 +339,14 @@ state = "working"
 subtags = [ "monitoring" ]
 url = "https://github.com/YunoHost-Apps/cachet_ynh"
 
+[caerp]
+added_date = 1674232499 # 2023/01/20
+category = "productivity_and_management"
+level = 0
+state = "working"
+subtags = [ "accounting", "business_and_ngos" ]
+url = "https://github.com/Yunohost-Apps/caerp_ynh"
+
 [calckey]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
@@ -991,14 +999,6 @@ deprecated_date = 1717071136 # 2024/05/30
 level = 7
 state = "working"
 url = "https://github.com/YunoHost-Apps/encryptor-decryptor_ynh"
-
-[endi]
-added_date = 1674232499 # 2023/01/20
-category = "productivity_and_management"
-level = 0
-state = "working"
-subtags = [ "accounting", "business_and_ngos" ]
-url = "https://github.com/Yunohost-Apps/endi_ynh"
 
 [epicyon]
 added_date = 1674232499 # 2023/01/20


### PR DESCRIPTION
tl;dr project was partially renamed (endi still exists, it's just a "branding" of caerp now).