### PR TITLE
Bump `ynh` number on non-main-asset-only updates.

### DIFF
--- a/tools/autoupdate_app_sources/requirements.txt
+++ b/tools/autoupdate_app_sources/requirements.txt
@@ -2,4 +2,3 @@ requests
 PyGithub
 toml
 tqdm
-GitPython


### PR DESCRIPTION
1.
For:

```toml
version = "2024.07.13~ynh8"

[resources]

    [resources.sources]
        [resources.sources.main]
        url = "https://github.com/TeamPiped/Piped/archive/87e2c4f6ac047630528a327dd9a29dd0f261221f.tar.gz"
        sha256 = "42a3830b4a040f5d0797a94774b2fa61a0f4d0211d08375ff8ba38157aa4f053"
        autoupdate.strategy = "latest_github_commit"

        [resources.sources.api]
        url = "https://github.com/TeamPiped/Piped-Backend/archive/6380cea805d1bd95655e29a90321f09aeb3bb99a.tar.gz"
        sha256 = "8f59b33faa23a714100d04134016adc999f8037522016e25e7a00920eb0e4219"
        autoupdate.strategy = "latest_github_commit"
        autoupdate.upstream = "https://github.com/TeamPiped/Piped-Backend/"
```

- Iff `main` asset updates version will bump to `some-date~ynh1`.  (i.e. `2024.07.15~ynh1`). That's the current behavior.
- Iff only `api` asset has new version `version` in manifest will bump to `2024.07.13~ynh9`. (NEW!)

2. Provide links for change logs:
- `main` v2023.09.17: https://codeberg.org/teddit/teddit/compare/25e789fdad6e8f66e2eefff1fb37ef982d6f6dd9...4536a7f4608f0f17bbee4188f9875fad8bfa954f
- `mineclone2` v0.87.2: https://git.minetest.land/VoxeLibre/VoxeLibre/releases/tag/0.87.2
- `capturetheflag` v3.9: https://github.com/MT-CTF/capturetheflag/releases/tag/v3.9

3. Cleaned up `requirements.txt`