### PR TITLE
add antifeatures to netdata

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2596,6 +2596,7 @@ url = "https://github.com/YunoHost-Apps/navidrome_ynh"
 
 [netdata]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "non-free-dependencies", "not-totally-free-upstream" ]
 category = "system_tools"
 level = 8
 state = "working"

--- a/apps.toml
+++ b/apps.toml
@@ -2596,7 +2596,7 @@ url = "https://github.com/YunoHost-Apps/navidrome_ynh"
 
 [netdata]
 added_date = 1674232499 # 2023/01/20
-antifeatures = [ "non-free-dependencies", "not-totally-free-upstream" ]
+antifeatures = [ "not-totally-free-upstream" ]
 category = "system_tools"
 level = 8
 state = "working"


### PR DESCRIPTION
for a couple of versions, netdata now includes a dependencie to a UI which is under a license that forbids reverse engineering or customisation

for me it's a shady subject, does it is still 'Free Software' if we can't study and customize it?

> The Software is provided in a binary form for use by end-users. You may not reverse engineer, decompile, disassemble, or modify the Software. The Software is licensed as a single product and its component parts may not be separated.

https://github.com/netdata/netdata/blob/master/src/web/gui/v2/LICENSE.md#restrictions

see:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1045145
- https://fellies.social/@wolfshappen/112972504848921803

i'm not sure about which antifeature to use, so i put both "non-free-dependencies" and "not-totally-free-upstream" but we have to choose before merging