### PR TITLE
add bad-security-reputation& deprecated-software antifeatures to halcyon

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1514,6 +1514,7 @@ url = "https://github.com/YunoHost-Apps/h5ai_ynh"
 
 [halcyon]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "bad-security-reputation", "deprecated-software" ]
 category = "social_media"
 level = 6
 potential_alternative_to = [ "X" ]


### PR DESCRIPTION
1. The upstream is unmaintained for 4 years
2. `! The app currently runs on php7.4 which is pretty old (unsupported by the PHP group since January 2023). Ideally, upgrade it to at least php8.2. `
3. At least 2 possible XSS vulnerabilities:
   - [#125 XSS vulnerability: Alt Text](https://notabug.org/halcyon-suite/halcyon/issues/125)
   - [#126 XSS vulnerability: Polls](https://notabug.org/halcyon-suite/halcyon/issues/126)

so i added `antifeatures = [ "bad-security-reputation", "deprecated-software" ]` to the package