### PR TITLE
Added curl_tests to tests.toml schema.

### DIFF
--- a/schemas/tests.v1.schema.json
+++ b/schemas/tests.v1.schema.json
@@ -32,9 +32,6 @@
                         },
                         {
                             "type": "boolean"
-                        },
-                        {
-                            "$ref": "#/$defs/install_args"
                         }
                     ]
                 }

--- a/schemas/tests.v1.schema.json
+++ b/schemas/tests.v1.schema.json
@@ -3,17 +3,19 @@
     "$id": "https://raw.githubusercontent.com/YunoHost/apps/master/schemas/tests.v1.schema.json",
     "title": "Yunohost app package tests.toml schema",
     "version": "0",
-
     "type": "object",
-    "required": ["test_format", "default"],
-
+    "required": [
+        "test_format",
+        "default"
+    ],
     "properties": {
-        "test_format": {"type": "number"}
+        "test_format": {
+            "type": "number"
+        }
     },
     "additionalProperties": {
         "$ref": "#/$defs/test_suite"
     },
-
     "$defs": {
         "install_args": {
             "type": "object",
@@ -22,9 +24,15 @@
             "patternProperties": {
                 "^[a-z][a-z0-9_]*$": {
                     "anyOf": [
-                        {"type": "string"},
-                        {"type": "number"},
-                        {"type": "boolean"}
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "boolean"
+                        }
                     ]
                 }
             }
@@ -49,7 +57,9 @@
                 "preinstall": {
                     "type": "string"
                 },
-                "args": {"$ref": "#/$defs/install_args"},
+                "args": {
+                    "$ref": "#/$defs/install_args"
+                },
                 "test_upgrade_from": {
                     "type": "object",
                     "required": [],
@@ -63,8 +73,43 @@
                                 "name": {
                                     "type": "string"
                                 },
-                                "args": {"$ref": "#/$defs/install_args"}
+                                "args": {
+                                    "$ref": "#/$defs/install_args"
+                                }
                             }
+                        }
+                    }
+                },
+                "curl_tests": {
+                    "type": "object",
+                    "required": [],
+                    "additionalProperties": false,
+                    "properties": {
+                        "base_url": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "logged_on_sso": {
+                            "type": "boolean"
+                        },
+                        "expect_title": {
+                            "type": "string"
+                        },
+                        "expect_content": {
+                            "type": "string"
+                        },
+                        "expect_return_code": {
+                            "type": "integer"
+                        },
+                        "expect_effective_url": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "auto_test_assets": {
+                            "type": "boolean"
                         }
                     }
                 }

--- a/schemas/tests.v1.schema.json
+++ b/schemas/tests.v1.schema.json
@@ -32,6 +32,9 @@
                         },
                         {
                             "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/$defs/install_args"
                         }
                     ]
                 }
@@ -82,34 +85,39 @@
                 },
                 "curl_tests": {
                     "type": "object",
-                    "required": [],
-                    "additionalProperties": false,
-                    "properties": {
-                        "base_url": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "logged_on_sso": {
-                            "type": "boolean"
-                        },
-                        "expect_title": {
-                            "type": "string"
-                        },
-                        "expect_content": {
-                            "type": "string"
-                        },
-                        "expect_return_code": {
-                            "type": "integer"
-                        },
-                        "expect_effective_url": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "auto_test_assets": {
-                            "type": "boolean"
+                    "patternProperties": {
+                        "^[a-z][a-z0-9_]*$": {
+                            "type": "object",
+                            "required": [],
+                            "additionalProperties": false,
+                            "properties": {
+                                "base_url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "logged_on_sso": {
+                                    "type": "boolean"
+                                },
+                                "expect_title": {
+                                    "type": "string"
+                                },
+                                "expect_content": {
+                                    "type": "string"
+                                },
+                                "expect_return_code": {
+                                    "type": "integer"
+                                },
+                                "expect_effective_url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "auto_test_assets": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Allow defining the `curl_tests` section

```toml
[default]
    [default.curl_tests]
    suite1.logged_on_sso = true
    suite1.expect_return_code = 401

    suite2.base_url = "https://why-would-you-do-that.com"
    suite2.path = "/new/path/"
    suite2.logged_on_sso = true
    suite2.expect_title = "awesome title"
    suite2.expect_content = "Denied, lol"
    suite2.expect_return_code = 418
    suite2.expect_effective_url = "https://why-would-you-do-that.com/new/path/redirected"
    suite2.auto_test_assets = false
```