### PR TITLE
Move icecoder to graveyard

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1813,16 +1813,6 @@ level = 7
 state = "working"
 url = "https://github.com/YunoHost-Apps/icecast2_ynh"
 
-[icecoder]
-added_date = 1674232499 # 2023/01/20
-antifeatures = [ "deprecated-software" ]
-category = "dev"
-deprecated_date = 1708146376 # 2024/02/17
-level = 0
-state = "working"
-subtags = [ "programming" ]
-url = "https://github.com/YunoHost-Apps/icecoder_ynh"
-
 [iceshrimp]
 added_date = 1703341532 # 2023/12/23
 category = "social_media"

--- a/graveyard.toml
+++ b/graveyard.toml
@@ -152,6 +152,13 @@ category = "publishing"
 killed_date = 1703600553 # 2023/12/26
 url = "https://github.com/YunoHost-Apps/gogs_webhost_ynh"
 
+[icecoder]
+added_date = 1674232499 # 2023/01/20
+category = "dev"
+deprecated_date = 1708146376 # 2024/02/17
+subtags = [ "programming" ]
+url = "https://github.com/YunoHost-Apps/icecoder_ynh"
+
 [internetarchive]
 added_date = 1569663577 # 2019/09/28
 category = "wat"


### PR DESCRIPTION
App is EOL upstream, CI is broken.