### PR TITLE
Manually fix redirect app.

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3641,7 +3641,7 @@ url = "https://github.com/YunoHost-Apps/readeck_ynh"
 [redirect]
 added_date = 1674232499 # 2023/01/20
 category = "publishing"
-level = 1
+level = 8
 state = "working"
 subtags = [ "website" ]
 url = "https://github.com/YunoHost-Apps/redirect_ynh"


### PR DESCRIPTION
It's only borked because tests are relying on the yunohost.org/path/ that was not updated for the CI. The app is working.
See https://ci-apps.yunohost.org/ci/job/12693