### PR TITLE
Set mollysocket as working

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2646,7 +2646,7 @@ url = "https://github.com/YunoHost-Apps/mobilizon_ynh"
 added_date = 1729641185 # 2024/10/22
 category = "communication"
 level = 0
-state = "inprogress"
+state = "working"
 subtags = [ "chat" ]
 url = "https://github.com/YunoHost-Apps/mollysocket_ynh"
 


### PR DESCRIPTION
Now that Yunohost 12 is out and set as minimum version the binary works.