### PR TITLE
schemas/tests: Allow expect_return_code to be a list of integers

### DIFF
--- a/schemas/tests.v1.schema.json
+++ b/schemas/tests.v1.schema.json
@@ -108,7 +108,17 @@
                                     "type": "string"
                                 },
                                 "expect_return_code": {
-                                    "type": "integer"
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "integers"
+                                            }
+                                        }
+                                    ]
                                 },
                                 "expect_effective_url": {
                                     "type": "string",


### PR DESCRIPTION
tl;dr xwiki would need 200 and 202