### PR TITLE
Consider 'visible' a valid option in install arguments.

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -307,15 +307,16 @@
                                 }
                             }
                         },
-                        "visible":
+                        "visible": {
                             "oneOf": [
-                            {
-                                "type": "bool"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
+                                {
+                                    "type": "bool"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
                     }
                 }
             }

--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -306,6 +306,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "visible" {
+                            "type": "string"
                         }
                     }
                 }

--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -307,9 +307,15 @@
                                 }
                             }
                         },
-                        "visible" {
-                            "type": "string"
-                        }
+                        "visible":
+                            "oneOf": [
+                            {
+                                "type": "bool"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
As per [the only valid and up to date documentation](https://github.com/YunoHost/yunohost/blob/cfeb8067e47dc50b5f66a05df4a173b34b88c058/src/utils/form.py#L353), form options, including install args, support conditional visibility via `visible` argument.

Tested, works: https://github.com/YunoHost-Apps/lychee_ynh/pull/144