### PR TITLE
Set Owntracks as notworking

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3287,7 +3287,7 @@ url = "https://github.com/YunoHost-Apps/owncloud_ynh"
 added_date = 1674232499 # 2023/01/20
 category = "small_utilities"
 level = 6
-state = "working"
+state = "notworking"
 url = "https://github.com/YunoHost-Apps/owntracks_ynh"
 
 [pagure]


### PR DESCRIPTION
https://github.com/YunoHost-Apps/owntracks_ynh/issues/50

Frustrated user is right, despite the app being successfully installed, it is absolutely not functional and requires sensibly more configuration in the package.