### PR TITLE
Move Firefish to graveyard

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1357,16 +1357,6 @@ potential_alternative_to = [ "Googles FindMyDevice" ]
 state = "working"
 url = "https://github.com/YunoHost-Apps/findmydevice_ynh"
 
-[firefish]
-added_date = 1691055044 # 2023/08/03
-antifeatures = [ "deprecated-software" ]
-category = "social_media"
-deprecated_date = 1742710147 # 2025/03/23
-level = 0
-potential_alternative_to = [ "Calckey", "Mastodon", "Misskey", "Pleroma", "Threads", "X" ]
-state = "working"
-url = "https://github.com/YunoHost-Apps/firefish_ynh"
-
 [firefly-iii]
 added_date = 1674232499 # 2023/01/20
 category = "productivity_and_management"

--- a/graveyard.toml
+++ b/graveyard.toml
@@ -111,6 +111,13 @@ deprecated_date = 1660842060 # 2022/08/18
 killed_date = 1716321298 # 2024/05/21
 url = "https://github.com/YunoHost-Apps/ffsync_ynh"
 
+[firefish]
+added_date = 1691055044 # 2023/08/03
+antifeatures = [ "deprecated-software" ]
+category = "social_media"
+deprecated_date = 1742710147 # 2025/03/23
+url = "https://github.com/YunoHost-Apps/firefish_ynh"
+
 [flask]
 added_date = 1554588215 # 2019/04/07
 category = "dev"


### PR DESCRIPTION
Firefish reached EOL at the end of 2024 and its homepage, https://firefish.dev no longer ships the code, hence the app is not installable anymore.