### PR TITLE
Put "redirect" in small utilities category

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3982,10 +3982,10 @@ url = "https://github.com/YunoHost-Apps/readeck_ynh"
 
 [redirect]
 added_date = 1674232499 # 2023/01/20
-category = "publishing"
+category = "small_utilities"
 level = 8
 state = "working"
-subtags = [ "website" ]
+subtags = [ "proxy" ]
 url = "https://github.com/YunoHost-Apps/redirect_ynh"
 
 [redlib]


### PR DESCRIPTION
"redirect" was in publication category which is mainly for web CMS. It would be easier to find in utilities. Additionaly the subtag proxy was added.