### PR TITLE
move DumbWhois in utilities

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1097,10 +1097,9 @@ url = "https://github.com/YunoHost-Apps/dumbpad_ynh"
 
 [dumbwhois]
 added_date = 1740438470 # 2025/02/24
-category = "system_tools"
+category = "small_utilities"
 level = 7
 state = "working"
-subtags = [ "network" ]
 url = "https://github.com/yunoHost-Apps/dumbwhois_ynh"
 
 [duniter]


### PR DESCRIPTION
it is expected to be in utilities because you don't really use it for system managing