### PR TITLE
move Readeck in reading cat.

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3976,7 +3976,7 @@ url = "https://github.com/YunoHost-Apps/readarr_ynh"
 
 [readeck]
 added_date = 1707572608 # 2024/02/10
-category = "small_utilities"
+category = "reading"
 level = 8
 state = "working"
 url = "https://github.com/YunoHost-Apps/readeck_ynh"


### PR DESCRIPTION
Software similar to Wallabag, so moved it in the same category.