### PR TITLE
move ifconfig-io to System Tools > Network

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2000,9 +2000,10 @@ url = "https://github.com/YunoHost-Apps/iceshrimp_ynh"
 
 [ifconfig-io]
 added_date = 1674232499 # 2023/01/20
-category = "small_utilities"
+category = "system_tools"
 level = 8
 state = "working"
+subtags = [ "network" ]
 url = "https://github.com/YunoHost-Apps/ifconfig-io_ynh"
 
 [ifm]


### PR DESCRIPTION
Intended to make it more discoverable. Useful tool for dev and sysadmin, not for end users.