### PR TITLE
Move proxy apps in same cat

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -408,10 +408,10 @@ url = "https://github.com/YunoHost-Apps/breezewiki_ynh"
 [cac-proxy]
 added_date = 1674232499 # 2023/01/20
 branch = "main"
-category = "system_tools"
+category = "small_utilities"
 level = 8
 state = "working"
-subtags = [ "network" ]
+subtags = [ "proxy" ]
 url = "https://github.com/yunoHost-Apps/cac-proxy_ynh"
 
 [cachet]
@@ -4054,10 +4054,10 @@ url = "https://github.com/YunoHost-Apps/revealjs_ynh"
 
 [reverseproxy]
 added_date = 1674232499 # 2023/01/20
-category = "system_tools"
+category = "small_utilities"
 level = 8
 state = "working"
-subtags = [ "network" ]
+subtags = [ "proxy" ]
 url = "https://github.com/YunoHost-Apps/reverseproxy_ynh"
 
 [rocketchat]
@@ -5193,10 +5193,10 @@ url = "https://github.com/YunoHost-Apps/zola_ynh"
 
 [zoraxy]
 added_date = 1725542118 # 2024/09/05
-category = "system_tools"
+category = "small_utilities"
 level = 7
 state = "working"
-subtags = [ "network" ]
+subtags = [ "proxy" ]
 url = "https://github.com/YunoHost-Apps/zoraxy_ynh"
 
 [ztncui]


### PR DESCRIPTION
Do not merge, let's discuss. 
cac-proxy and zoraxy moved from system_tools > network to small-utilities > proxy.  Obviously, Small-Utilities is not the right cat, should be better to move the proxy subcat and its content to System-Tools.