### PR TITLE
move Linkwarden from publishing to reading

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2490,7 +2490,7 @@ url = "https://github.com/YunoHost-Apps/linkstack_ynh"
 
 [linkwarden]
 added_date = 1729028717 # 2024/10/15
-category = "publishing"
+category = "reading"
 level = 7
 potential_alternative_to = [ "Shaarli", "Wallabag" ]
 state = "working"


### PR DESCRIPTION
It is more about building private or collaborative collections for work than sharing them publicly. 
Similar to Wallabag