### PR TITLE
add subtags to fab-manager

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1290,6 +1290,7 @@ added_date = 1674232499 # 2023/01/20
 category = "productivity_and_management"
 level = 8
 state = "working"
+subtags = [ "business_and_ngos", "accounting" ]
 url = "https://github.com/YunoHost-Apps/fab-manager_ynh"
 
 [faceprivacy]


### PR DESCRIPTION
Fab-manager simplify administrative tasks and can do accounting (Gestion comptable). Add business and accouting subtags