### PR TITLE
move Metabase from monitoring to db

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2774,7 +2774,7 @@ added_date = 1674232499 # 2023/01/20
 category = "system_tools"
 level = 8
 state = "working"
-subtags = [ "monitoring" ]
+subtags = [ "db" ]
 url = "https://github.com/YunoHost-Apps/metabase_ynh"
 
 [metronome]


### PR DESCRIPTION
Metabase is not a monitoring tool but an analytic tool used to explore a database.