### PR TITLE
move Agora from Wat to Office category

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -120,7 +120,7 @@ url = "https://github.com/YunoHost-Apps/agewasm_ynh"
 
 [agora]
 added_date = 1674232499 # 2023/01/20
-category = "wat"
+category = "office"
 level = 8
 state = "working"
 url = "https://github.com/YunoHost-Apps/agora_ynh"


### PR DESCRIPTION
Agora is a tool for teams collaboration, much like Tracim (which is already in Office)