### PR TITLE
remove antifeatures for JSON Crack

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2267,7 +2267,6 @@ url = "https://github.com/YunoHost-Apps/joplin_ynh"
 
 [jsoncrack]
 added_date = 1732845261 # 2024/11/29
-antifeatures = [ "not-totally-free-upstream" ]
 category = "small_utilities"
 level = 7
 state = "working"


### PR DESCRIPTION
Upstream app now under free license (Apache 2.0)