### PR TITLE
Define explicitly branch in apps.toml

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -2,6 +2,7 @@
 
 [13ft]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "12ft" ]
@@ -11,6 +12,7 @@ url = "https://github.com/YunoHost-Apps/13ft_ynh"
 [20euros]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-assets" ]
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -18,6 +20,7 @@ url = "https://github.com/YunoHost-Apps/20euros_ynh"
 
 [243-game]
 added_date = 1680384741 # 2023/04/01
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -25,6 +28,7 @@ url = "https://github.com/YunoHost-Apps/243-game_ynh"
 
 [299ko]
 added_date = 1741549970 # 2025/03/09
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -33,6 +37,7 @@ url = "https://github.com/YunoHost-Apps/299ko_ynh"
 
 [2fauth]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -40,6 +45,7 @@ url = "https://github.com/YunoHost-Apps/2fauth_ynh"
 
 [abantecart]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 3
 state = "working"
@@ -49,6 +55,7 @@ url = "https://github.com/YunoHost-Apps/abantecart_ynh"
 [acropolis]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "social_media"
 deprecated_date = 1717071136 # 2024/05/30
 level = 0
@@ -58,6 +65,7 @@ url = "https://github.com/YunoHost-Apps/acropolis_ynh"
 
 [actual]
 added_date = 1685962455 # 2023/06/05
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Bankin", "Budgea", "Linxo", "Microsoft Money", "Mint", "You Need A Budget" ]
@@ -67,6 +75,7 @@ url = "https://github.com/YunoHost-Apps/actual_ynh"
 
 [adguardhome]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -75,6 +84,7 @@ url = "https://github.com/YunoHost-Apps/adguardhome_ynh"
 
 [adminer]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 deprecated_date = 1717071136 # 2024/05/30
 level = 8
@@ -84,6 +94,7 @@ url = "https://github.com/YunoHost-Apps/adminer_ynh"
 
 [adminerevo]
 added_date = 1724948610 # 2024/08/29
+branch = "master"
 category = "system_tools"
 level = 8
 potential_alternative_to = [ "phpMyAdmin" ]
@@ -102,6 +113,7 @@ url = "https://github.com/YunoHost-Apps/adventurelog_ynh"
 [aeneria]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "iot"
 deprecated_date = 1729517763 # 2024/10/21
 level = 0
@@ -111,6 +123,7 @@ url = "https://github.com/YunoHost-Apps/aeneria_ynh"
 [agendav]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "synchronization"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -121,6 +134,7 @@ url = "https://github.com/YunoHost-Apps/agendav_ynh"
 
 [agewasm]
 added_date = 1734129289 # 2024/12/13
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -128,6 +142,7 @@ url = "https://github.com/YunoHost-Apps/agewasm_ynh"
 
 [agora]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -135,6 +150,7 @@ url = "https://github.com/YunoHost-Apps/agora_ynh"
 
 [agorakit]
 added_date = 1741016099 # 2025/03/03
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -142,6 +158,7 @@ url = "https://github.com/YunoHost-Apps/agorakit_ynh"
 
 [airsonic]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 potential_alternative_to = [ "Deezer", "SoundCloud", "Spotify" ]
@@ -151,6 +168,7 @@ url = "https://github.com/YunoHost-Apps/airsonic_ynh"
 
 [akkoma]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "Firefish", "Gotosocial", "Mastodon", "Misskey", "Pleroma", "X" ]
@@ -161,6 +179,7 @@ url = "https://github.com/YunoHost-Apps/akkoma_ynh"
 [alltube]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software", "non-free-network" ]
+branch = "master"
 category = "multimedia"
 deprecated_date = 1708018611 # 2024/02/15
 level = 6
@@ -171,6 +190,7 @@ url = "https://github.com/YunoHost-Apps/alltube_ynh"
 
 [ampache]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Deezer", "SoundCloud", "Spotify" ]
@@ -180,6 +200,7 @@ url = "https://github.com/YunoHost-Apps/ampache_ynh"
 
 [anarchism]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 potential_alternative_to = [ "Capitalism" ]
@@ -197,6 +218,7 @@ url = "https://github.com/YunoHost-Apps/antigen_ynh"
 [appflowy]
 added_date = 1736881754 # 2025/01/14
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "publishing"
 level = 3
 potential_alternative_to = [ "Notion" ]
@@ -206,6 +228,7 @@ url = "https://github.com/YunoHost-Apps/appflowy_ynh"
 
 [archivebox]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -213,6 +236,7 @@ url = "https://github.com/YunoHost-Apps/archivebox_ynh"
 
 [archivist]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -221,6 +245,7 @@ url = "https://github.com/YunoHost-Apps/archivist_ynh"
 
 [argos]
 added_date = 1738516618 # 2025/02/02
+branch = "master"
 category = "system_tools"
 level = 0
 state = "notworking"
@@ -230,6 +255,7 @@ url = "https://github.com/YunoHost-Apps/argos_ynh"
 [armadietto]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "alpha-software" ]
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -238,6 +264,7 @@ url = "https://github.com/YunoHost-Apps/armadietto_ynh"
 [arn_messager]
 added_date = 1745602155 # 2025/04/25
 antifeatures = [ "alpha-software" ]
+branch = "master"
 category = "communication"
 level = 0
 state = "notworking"
@@ -245,6 +272,7 @@ url = "https://github.com/YunoHost-Apps/arn_messager_ynh"
 
 [audiobookshelf]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -252,6 +280,7 @@ url = "https://github.com/YunoHost-Apps/audiobookshelf_ynh"
 
 [autobd]
 added_date = 1729498404 # 2024/10/21
+branch = "master"
 category = "office"
 level = 7
 state = "working"
@@ -260,6 +289,7 @@ url = "https://github.com/YunoHost-Apps/autobd_ynh"
 
 [autobrr]
 added_date = 1681591997 # 2023/04/15
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -267,6 +297,7 @@ url = "https://github.com/YunoHost-Apps/autobrr_ynh"
 
 [automad]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -275,6 +306,7 @@ url = "https://github.com/YunoHost-Apps/automad_ynh"
 
 [backdrop]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -283,6 +315,7 @@ url = "https://github.com/YunoHost-Apps/backdrop_ynh"
 
 [backrest]
 added_date = 1729003252 # 2024/10/15
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -291,6 +324,7 @@ url = "https://github.com/YunoHost-Apps/backrest_ynh"
 
 [baikal]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 6
 potential_alternative_to = [ "Microsoft Outlook" ]
@@ -300,6 +334,7 @@ url = "https://github.com/YunoHost-Apps/baikal_ynh"
 
 [bazarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -308,6 +343,7 @@ url = "https://github.com/YunoHost-Apps/bazarr_ynh"
 [beehive]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "iot"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -316,6 +352,7 @@ url = "https://github.com/YunoHost-Apps/beehive_ynh"
 
 [benevalibre]
 added_date = 1737885571 # 2025/01/26
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -324,6 +361,7 @@ url = "https://github.com/YunoHost-Apps/benevalibre_ynh"
 
 [biboumi]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -332,6 +370,7 @@ url = "https://github.com/YunoHost-Apps/biboumi_ynh"
 
 [bicbucstriim]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -349,6 +388,7 @@ url = "https://github.com/YunoHost-Apps/bileto_ynh"
 
 [bloat]
 added_date = 1731593020 # 2024/11/14
+branch = "master"
 category = "social_media"
 level = 7
 state = "working"
@@ -358,6 +398,7 @@ url = "https://github.com/YunoHost-Apps/bloat_ynh"
 [blogotext]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -368,6 +409,7 @@ url = "https://github.com/YunoHost-Apps/blogotext_ynh"
 
 [bludit]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -376,6 +418,7 @@ url = "https://github.com/YunoHost-Apps/bludit_ynh"
 
 [bonfire]
 added_date = 1706290061 # 2024/01/26
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "Akkoma", "Calckey", "Iceshrimp", "Mastodon", "Misskey", "Pleroma" ]
@@ -384,6 +427,7 @@ url = "https://github.com/YunoHost-Apps/bonfire_ynh"
 
 [bookstack]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "GitBook", "Notion" ]
@@ -394,6 +438,7 @@ url = "https://github.com/YunoHost-Apps/bookstack_ynh"
 [bookwyrm]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Goodreads" ]
@@ -402,6 +447,7 @@ url = "https://github.com/YunoHost-Apps/bookwyrm_ynh"
 
 [borg]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 potential_alternative_to = [ "Time Machine", "Veeam" ]
@@ -411,6 +457,7 @@ url = "https://github.com/YunoHost-Apps/borg_ynh"
 
 [borgserver]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -419,6 +466,7 @@ url = "https://github.com/YunoHost-Apps/borgserver_ynh"
 
 [borgwarehouse]
 added_date = 1697570631 # 2023/10/17
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -427,6 +475,7 @@ url = "https://github.com/YunoHost-Apps/borgwarehouse_ynh"
 
 [breezewiki]
 added_date = 1726556685 # 2024/09/17
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -444,6 +493,7 @@ url = "https://github.com/yunoHost-Apps/cac-proxy_ynh"
 
 [cachet]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 potential_alternative_to = [ "StatusHub" ]
@@ -453,6 +503,7 @@ url = "https://github.com/YunoHost-Apps/cachet_ynh"
 
 [caerp]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 0
 state = "notworking"
@@ -461,6 +512,7 @@ url = "https://github.com/Yunohost-Apps/caerp_ynh"
 
 [calibreweb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -469,6 +521,7 @@ url = "https://github.com/YunoHost-Apps/calibreweb_ynh"
 
 [castopod]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Anchor", "Apple Podcasts", "Audible", "Deezer", "SoundCloud", "Spotify" ]
@@ -477,6 +530,7 @@ url = "https://github.com/YunoHost-Apps/castopod_ynh"
 
 [cesium]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -484,6 +538,7 @@ url = "https://github.com/YunoHost-Apps/cesium_ynh"
 
 [changedetection]
 added_date = 1741682395 # 2025/03/11
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -493,6 +548,7 @@ url = "https://github.com/YunoHost-Apps/changedetection_ynh"
 [chatgpt-web]
 added_date = 1684063245 # 2023/05/14
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -500,6 +556,7 @@ url = "https://github.com/YunoHost-Apps/chatgpt-web_ynh"
 
 [chatonsinfos]
 added_date = 1701295269 # 2023/11/29
+branch = "master"
 category = "wat"
 level = 0
 state = "working"
@@ -508,6 +565,7 @@ url = "https://github.com/YunoHost-Apps/chatonsinfos_ynh"
 [cheky]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -516,6 +574,7 @@ url = "https://github.com/YunoHost-Apps/cheky_ynh"
 
 [chitchatter]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 state = "working"
@@ -524,6 +583,7 @@ url = "https://github.com/YunoHost-Apps/chitchatter_ynh"
 
 [chyrplite]
 added_date = 1682991333 # 2023/05/02
+branch = "master"
 category = "publishing"
 level = 0
 state = "notworking"
@@ -532,6 +592,7 @@ url = "https://github.com/YunoHost-Apps/chyrplite_ynh"
 
 [cinny]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -541,6 +602,7 @@ url = "https://github.com/YunoHost-Apps/cinny_ynh"
 
 [civicrm_drupal]
 added_date = 1733905652 # 2024/12/11
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -550,6 +612,7 @@ url = "https://github.com/YunoHost-Apps/civicrm_drupal_ynh"
 [civicrm_drupal7]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "productivity_and_management"
 deprecated_date = 1733864912 # 2024/12/10
 level = 0
@@ -559,6 +622,7 @@ url = "https://github.com/YunoHost-Apps/civicrm_drupal7_ynh"
 
 [cjdns]
 added_date = 1703094732 # 2023/12/20
+branch = "master"
 category = "system_tools"
 level = 0
 state = "working"
@@ -567,6 +631,7 @@ url = "https://github.com/YunoHost-Apps/cjdns_ynh"
 
 [cloudlog]
 added_date = 1685981922 # 2023/06/05
+branch = "master"
 category = "small_utilities"
 level = 6
 state = "working"
@@ -574,6 +639,7 @@ url = "https://github.com/YunoHost-Apps/cloudlog_ynh"
 
 [cockpit]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -582,6 +648,7 @@ url = "https://github.com/YunoHost-Apps/cockpit_ynh"
 
 [code-server]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 6
 state = "working"
@@ -590,6 +657,7 @@ url = "https://github.com/YunoHost-Apps/code-server_ynh"
 
 [codimd]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Google Docs" ]
@@ -599,6 +667,7 @@ url = "https://github.com/YunoHost-Apps/codimd_ynh"
 
 [coin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -607,6 +676,7 @@ url = "https://github.com/YunoHost-Apps/coin_ynh"
 
 [collabora]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Apple Pages", "G Suite", "Google Docs", "Microsoft Excel", "Microsoft Office", "Microsoft Word" ]
@@ -616,6 +686,7 @@ url = "https://github.com/YunoHost-Apps/collabora_ynh"
 
 [commafeed]
 added_date = 1732873062 # 2024/11/29
+branch = "master"
 category = "reading"
 level = 7
 potential_alternative_to = [ "Feedly", "Google Reader", "Netvibes" ]
@@ -626,6 +697,7 @@ url = "https://github.com/YunoHost-Apps/commafeed_ynh"
 [commento]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -636,6 +708,7 @@ url = "https://github.com/YunoHost-Apps/commento_ynh"
 
 [commet]
 added_date = 1728925760 # 2024/10/14
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Cinny", "Discord", "Element", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -645,6 +718,7 @@ url = "https://github.com/YunoHost-Apps/commet_ynh"
 
 [compteur_du_gase]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 6
 state = "working"
@@ -652,6 +726,7 @@ url = "https://github.com/YunoHost-Apps/compteur_du_gase_ynh"
 
 [concrete5]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -660,6 +735,7 @@ url = "https://github.com/YunoHost-Apps/concrete5_ynh"
 
 [conduit]
 added_date = 1691780437 # 2023/08/11
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -669,6 +745,7 @@ url = "https://github.com/YunoHost-Apps/conduit_ynh"
 
 [converse]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -679,6 +756,7 @@ url = "https://github.com/YunoHost-Apps/converse_ynh"
 [convos]
 added_date = 1727292993 # 2024/09/25
 antifeatures = [ "not-totally-free-package" ]
+branch = "master"
 category = "communication"
 level = 7
 state = "working"
@@ -688,6 +766,7 @@ url = "https://github.com/YunoHost-Apps/convos_ynh"
 [cops]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "reading"
 level = 6
 state = "working"
@@ -702,6 +781,7 @@ url = "https://github.com/YunoHost-Apps/copyparty_ynh"
 
 [coturn]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -710,6 +790,7 @@ url = "https://github.com/YunoHost-Apps/coturn_ynh"
 
 [couchdb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -719,6 +800,7 @@ url = "https://github.com/YunoHost-Apps/couchdb_ynh"
 [couchpotato]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software", "package-not-maintained" ]
+branch = "master"
 category = "multimedia"
 deprecated_date = 1717071136 # 2024/05/30
 level = 0
@@ -729,6 +811,7 @@ url = "https://github.com/YunoHost-Apps/couchpotato_ynh"
 
 [cowyo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -737,6 +820,7 @@ url = "https://github.com/YunoHost-Apps/cowyo_ynh"
 
 [crabfit]
 added_date = 1710114839 # 2024/03/10
+branch = "master"
 category = "productivity_and_management"
 level = 7
 potential_alternative_to = [ "Doodle", "OpenSondage" ]
@@ -746,6 +830,7 @@ url = "https://github.com/YunoHost-Apps/crabfit_ynh"
 
 [cryptpad]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Apple Pages", "G Suite", "Google Docs", "Microsoft Excel", "Microsoft Excel", "Microsoft Office", "Microsoft Word" ]
@@ -764,6 +849,7 @@ url = "https://github.com/YunoHost-Apps/cryptroot-unlock_ynh"
 [cubiks-2048]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "tracking" ]
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -771,6 +857,7 @@ url = "https://github.com/YunoHost-Apps/cubiks-2048_ynh"
 
 [cultivons]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -778,6 +865,7 @@ url = "https://github.com/YunoHost-Apps/cultivons_ynh"
 
 [cusdis]
 added_date = 1725542096 # 2024/09/05
+branch = "master"
 category = "publishing"
 level = 7
 potential_alternative_to = [ "Disqus" ]
@@ -787,6 +875,7 @@ url = "https://github.com/YunoHost-Apps/cusdis_ynh"
 
 [custom_backup]
 added_date = 1722705585 # 2024/08/03
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -795,6 +884,7 @@ url = "https://github.com/YunoHost-Apps/custom_backup_ynh"
 
 [cyberchef]
 added_date = 1679078317 # 2023/03/17
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -802,6 +892,7 @@ url = "https://github.com/YunoHost-Apps/cyberchef_ynh"
 
 [cypht]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
@@ -811,6 +902,7 @@ url = "https://github.com/YunoHost-Apps/cypht_ynh"
 
 [dagu]
 added_date = 1729498404 # 2024/10/21
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -818,6 +910,7 @@ url = "https://github.com/YunoHost-Apps/dagu_ynh"
 
 [dato]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "FileMaker", "Microsoft Access" ]
@@ -826,6 +919,7 @@ url = "https://github.com/YunoHost-Apps/dato_ynh"
 
 [davis]
 added_date = 1744870294 # 2025/04/17
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "Microsoft Outlook" ]
@@ -835,6 +929,7 @@ url = "https://github.com/YunoHost-Apps/davis_ynh"
 
 [deluge]
 added_date = 1691487217 # 2023/08/08
+branch = "master"
 category = "multimedia"
 level = 6
 potential_alternative_to = [ "µTorrent" ]
@@ -845,6 +940,7 @@ url = "https://github.com/YunoHost-Apps/deluge_ynh"
 [dendrite]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "alpha-software" ]
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -854,6 +950,7 @@ url = "https://github.com/YunoHost-Apps/dendrite_ynh"
 
 [dex]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -862,6 +959,7 @@ url = "https://github.com/YunoHost-Apps/dex_ynh"
 
 [diacamma]
 added_date = 1702911143 # 2023/12/18
+branch = "master"
 category = "productivity_and_management"
 level = 6
 potential_alternative_to = [ "AssoConnect", "Ciel Associations", "HelloAsso" ]
@@ -871,6 +969,7 @@ url = "https://github.com/YunoHost-Apps/diacamma_ynh"
 
 [diagnostickoeur]
 added_date = 1741897932 # 2025/03/13
+branch = "master"
 category = "wat"
 level = 7
 state = "working"
@@ -878,6 +977,7 @@ url = "https://github.com/YunoHost-Apps/diagnostickoeur_ynh"
 
 [diagramsnet]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Visio" ]
@@ -887,6 +987,7 @@ url = "https://github.com/YunoHost-Apps/diagramsnet_ynh"
 
 [diaspora]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Ello", "Facebook", "Hubzilla", "Myspace", "X" ]
@@ -896,6 +997,7 @@ url = "https://github.com/YunoHost-Apps/diaspora_ynh"
 
 [digipad]
 added_date = 1729081913 # 2024/10/16
+branch = "master"
 category = "communication"
 level = 0
 potential_alternative_to = [ "Padlet" ]
@@ -904,6 +1006,7 @@ url = "https://github.com/YunoHost-Apps/digipad_ynh"
 
 [digiscreen]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -911,6 +1014,7 @@ url = "https://github.com/YunoHost-Apps/digiscreen_ynh"
 
 [digisteps]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -918,6 +1022,7 @@ url = "https://github.com/YunoHost-Apps/digisteps_ynh"
 
 [digitools]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -925,6 +1030,7 @@ url = "https://github.com/YunoHost-Apps/digitools_ynh"
 
 [digitranscode]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -932,6 +1038,7 @@ url = "https://github.com/YunoHost-Apps/digitranscode_ynh"
 
 [digiwords]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -939,6 +1046,7 @@ url = "https://github.com/YunoHost-Apps/digiwords_ynh"
 
 [directorylister]
 added_date = 1688911597 # 2023/07/09
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -946,6 +1054,7 @@ url = "https://github.com/YunoHost-Apps/directorylister_ynh"
 
 [discourse]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 0
 potential_alternative_to = [ "Invision Community", "XenForo", "vBulletin" ]
@@ -956,6 +1065,7 @@ url = "https://github.com/YunoHost-Apps/discourse_ynh"
 [dispatch]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "communication"
 deprecated_date = 1709075769 # 2024/02/27
 level = 7
@@ -966,6 +1076,7 @@ url = "https://github.com/YunoHost-Apps/dispatch_ynh"
 [distbin]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -975,6 +1086,7 @@ url = "https://github.com/YunoHost-Apps/distbin_ynh"
 
 [django-fmd]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 3
 potential_alternative_to = [ "Googles FindMyDevice" ]
@@ -983,6 +1095,7 @@ url = "https://github.com/YunoHost-Apps/django-fmd_ynh"
 
 [django-for-runners]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 6
 state = "working"
@@ -990,6 +1103,7 @@ url = "https://github.com/YunoHost-Apps/django-for-runners_ynh"
 
 [django-fritzconnection]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -998,6 +1112,7 @@ url = "https://github.com/YunoHost-Apps/django-fritzconnection_ynh"
 
 [django_example]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 3
 state = "working"
@@ -1006,6 +1121,7 @@ url = "https://github.com/YunoHost-Apps/django_example_ynh"
 
 [docsify]
 added_date = 1729698039 # 2024/10/23
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -1014,6 +1130,7 @@ url = "https://github.com/YunoHost-Apps/docsify_ynh"
 
 [documize]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Confluence" ]
@@ -1023,6 +1140,7 @@ url = "https://github.com/YunoHost-Apps/documize_ynh"
 
 [dodoc]
 added_date = 1727292905 # 2024/09/25
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -1032,6 +1150,7 @@ url = "https://github.com/YunoHost-Apps/dodoc_ynh"
 
 [dokos]
 added_date = 1744664001 # 2025/04/14
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -1040,6 +1159,7 @@ url = "https://github.com/YunoHost-Apps/dokos_ynh"
 
 [dokuwiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -1048,6 +1168,7 @@ url = "https://github.com/YunoHost-Apps/dokuwiki_ynh"
 
 [dolibarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -1056,6 +1177,7 @@ url = "https://github.com/YunoHost-Apps/dolibarr_ynh"
 
 [domoticz]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -1072,6 +1194,7 @@ url = "https://github.com/YunoHost-Apps/dont-code_ynh"
 
 [dotclear2]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -1080,6 +1203,7 @@ url = "https://github.com/YunoHost-Apps/dotclear2_ynh"
 
 [drupal]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -1089,6 +1213,7 @@ url = "https://github.com/YunoHost-Apps/drupal_ynh"
 [drupal7]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1733864912 # 2024/12/10
 level = 0
@@ -1098,6 +1223,7 @@ url = "https://github.com/YunoHost-Apps/drupal7_ynh"
 
 [dumbbudget]
 added_date = 1740438470 # 2025/02/24
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -1106,6 +1232,7 @@ url = "https://github.com/YunoHost-Apps/dumbbudget_ynh"
 
 [dumbdo]
 added_date = 1740434861 # 2025/02/24
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -1114,6 +1241,7 @@ url = "https://github.com/YunoHost-Apps/dumbdo_ynh"
 
 [dumbdrop]
 added_date = 1740434861 # 2025/02/24
+branch = "master"
 category = "synchronization"
 level = 7
 state = "working"
@@ -1122,6 +1250,7 @@ url = "https://github.com/YunoHost-Apps/dumbdrop_ynh"
 
 [dumbkan]
 added_date = 1740436963 # 2025/02/24
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -1130,6 +1259,7 @@ url = "https://github.com/YunoHost-Apps/dumbkan_ynh"
 
 [dumbpad]
 added_date = 1740434861 # 2025/02/24
+branch = "master"
 category = "office"
 level = 7
 state = "working"
@@ -1138,6 +1268,7 @@ url = "https://github.com/YunoHost-Apps/dumbpad_ynh"
 
 [dumbwhois]
 added_date = 1740438470 # 2025/02/24
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -1145,6 +1276,7 @@ url = "https://github.com/yunoHost-Apps/dumbwhois_ynh"
 
 [duniter]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -1152,6 +1284,7 @@ url = "https://github.com/YunoHost-Apps/duniter_ynh"
 
 [dynamicqrcode]
 added_date = 1721508308 # 2024/07/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1159,6 +1292,7 @@ url = "https://github.com/YunoHost-Apps/dynamicqrcode_ynh"
 
 [easyappointments]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Doctolib" ]
@@ -1168,6 +1302,7 @@ url = "https://github.com/YunoHost-Apps/easyappointments_ynh"
 
 [elabftw]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1176,6 +1311,7 @@ url = "https://github.com/YunoHost-Apps/elabftw_ynh"
 [elasticsearch7]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -1185,6 +1321,7 @@ url = "https://github.com/YunoHost-Apps/elasticsearch7_ynh"
 [elasticsearch8]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -1193,6 +1330,7 @@ url = "https://github.com/YunoHost-Apps/elasticsearch8_ynh"
 
 [element]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -1202,6 +1340,7 @@ url = "https://github.com/YunoHost-Apps/element_ynh"
 
 [element-call]
 added_date = 1697570605 # 2023/10/17
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Skype", "Zoom" ]
@@ -1211,6 +1350,7 @@ url = "https://github.com/YunoHost-Apps/element-call_ynh"
 
 [eleventy]
 added_date = 1683960849 # 2023/05/13
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Blogger", "Blogspot", "Wix" ]
@@ -1220,6 +1360,7 @@ url = "https://github.com/YunoHost-Apps/eleventy_ynh"
 
 [emailpoubelle]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 6
 potential_alternative_to = [ "Tempomail", "crazymailing.com", "jetable.org", "spamGourmet", "yopmail.com" ]
@@ -1228,6 +1369,7 @@ url = "https://github.com/YunoHost-Apps/emailpoubelle_ynh"
 
 [emoncms]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -1236,6 +1378,7 @@ url = "https://github.com/YunoHost-Apps/emoncms_ynh"
 [encryptor-decryptor]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -1244,6 +1387,7 @@ url = "https://github.com/YunoHost-Apps/encryptor-decryptor_ynh"
 
 [epicyon]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 state = "working"
@@ -1252,6 +1396,7 @@ url = "https://github.com/YunoHost-Apps/epicyon_ynh"
 
 [ergo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 state = "working"
@@ -1260,6 +1405,7 @@ url = "https://github.com/YunoHost-Apps/ergo_ynh"
 
 [esphome]
 added_date = 1738792904 # 2025/02/05
+branch = "master"
 category = "iot"
 level = 7
 state = "working"
@@ -1267,6 +1413,7 @@ url = "https://github.com/YunoHost-Apps/esphome_ynh"
 
 [espocrm]
 added_date = 1740318200 # 2025/02/23
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -1275,6 +1422,7 @@ url = "https://github.com/YunoHost-Apps/espocrm_ynh"
 [ethercalc]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "office"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -1285,6 +1433,7 @@ url = "https://github.com/YunoHost-Apps/ethercalc_ynh"
 
 [etherpad]
 added_date = 1694300530 # 2023/09/09
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "G Suite", "Google Docs", "Microsoft Office", "Microsoft Word", "Office 365" ]
@@ -1294,6 +1443,7 @@ url = "https://github.com/YunoHost-Apps/etherpad_ynh"
 
 [etherpad_mypads]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 6
 potential_alternative_to = [ "G Suite", "Google Docs", "Microsoft Office", "Microsoft Word", "Office 365" ]
@@ -1303,6 +1453,7 @@ url = "https://github.com/YunoHost-Apps/etherpad_mypads_ynh"
 
 [excalidraw]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Lucidchart" ]
@@ -1312,6 +1463,7 @@ url = "https://github.com/YunoHost-Apps/excalidraw_ynh"
 
 [fab-manager]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -1320,6 +1472,7 @@ url = "https://github.com/YunoHost-Apps/fab-manager_ynh"
 
 [faceprivacy]
 added_date = 1741876888 # 2025/03/13
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -1328,6 +1481,7 @@ url = "https://github.com/YunoHost-Apps/faceprivacy_ynh"
 [facette]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "system_tools"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -1337,6 +1491,7 @@ url = "https://github.com/YunoHost-Apps/facette_ynh"
 
 [facilmap]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1344,6 +1499,7 @@ url = "https://github.com/YunoHost-Apps/facilmap_ynh"
 
 [fail2ban-web]
 added_date = 1726556323 # 2024/09/17
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -1352,6 +1508,7 @@ url = "https://github.com/YunoHost-Apps/fail2ban-web_ynh"
 
 [faircamp]
 added_date = 1723843587 # 2024/08/16
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -1360,6 +1517,7 @@ url = "https://github.com/YunoHost-Apps/faircamp_ynh"
 
 [fastapi]
 added_date = 1701639252 # 2023/12/03
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -1368,6 +1526,7 @@ url = "https://github.com/YunoHost-Apps/fastapi_ynh"
 
 [fathom]
 added_date = 1740309112 # 2025/02/23
+branch = "master"
 category = "publishing"
 level = 7
 potential_alternative_to = [ "Google Analytics", "Xiti" ]
@@ -1377,6 +1536,7 @@ url = "https://github.com/YunoHost-Apps/fathom_ynh"
 
 [feber]
 added_date = 1723909952 # 2024/08/17
+branch = "master"
 category = "synchronization"
 level = 8
 state = "working"
@@ -1385,6 +1545,7 @@ url = "https://github.com/YunoHost-Apps/feber_ynh"
 
 [fider]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1393,6 +1554,7 @@ url = "https://github.com/YunoHost-Apps/fider_ynh"
 
 [filebrowser]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1400,6 +1562,7 @@ url = "https://github.com/YunoHost-Apps/filebrowser_ynh"
 
 [filepizza]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 deprecated_date = 1717071136 # 2024/05/30
 level = 8
@@ -1418,6 +1581,7 @@ url = "https://github.com/YunoHost-Apps/filerise_ynh"
 
 [findmydevice]
 added_date = 1732889996 # 2024/11/29
+branch = "master"
 category = "iot"
 level = 7
 potential_alternative_to = [ "Googles FindMyDevice" ]
@@ -1426,6 +1590,7 @@ url = "https://github.com/YunoHost-Apps/findmydevice_ynh"
 
 [firefly-iii]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Bankin", "Budgea", "Linxo", "Microsoft Money", "Mint", "You Need A Budget" ]
@@ -1435,6 +1600,7 @@ url = "https://github.com/YunoHost-Apps/firefly-iii_ynh"
 
 [firefly-iii-di]
 added_date = 1679303288 # 2023/03/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1443,6 +1609,7 @@ url = "https://github.com/YunoHost-Apps/firefly-iii-di_ynh"
 
 [fittrackee]
 added_date = 1678221457 # 2023/03/07
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "Strava" ]
@@ -1451,6 +1618,7 @@ url = "https://github.com/Yunohost-Apps/fittrackee_ynh"
 
 [flarum]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Invision Community", "XenForo", "vBulletin" ]
@@ -1460,6 +1628,7 @@ url = "https://github.com/YunoHost-Apps/flarum_ynh"
 
 [flohmarkt]
 added_date = 1714137502 # 2024/04/26
+branch = "master"
 category = "publishing"
 level = 6
 potential_alternative_to = [ "ClassifiedAds.com", "kleinanzeigen.de" ]
@@ -1469,6 +1638,7 @@ url = "https://github.com/YunoHost-Apps/flohmarkt_ynh"
 
 [flood]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -1477,6 +1647,7 @@ url = "https://github.com/YunoHost-Apps/flood_ynh"
 
 [fluffychat]
 added_date = 1704159048 # 2024/01/02
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -1485,6 +1656,7 @@ url = "https://github.com/YunoHost-Apps/fluffychat_ynh"
 
 [fluxbb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -1495,6 +1667,7 @@ url = "https://github.com/YunoHost-Apps/fluxbb_ynh"
 
 [focalboard]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Asana", "Notion", "Trello" ]
@@ -1504,6 +1677,7 @@ url = "https://github.com/YunoHost-Apps/focalboard_ynh"
 
 [fontcompare]
 added_date = 1734547348 # 2024/12/18
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -1511,6 +1685,7 @@ url = "https://github.com/Yunohost-Apps/fontcompare_ynh"
 
 [forgejo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "GitHub" ]
@@ -1520,6 +1695,7 @@ url = "https://github.com/YunoHost-Apps/forgejo_ynh"
 
 [forgejo_runner]
 added_date = 1737658668 # 2025/01/23
+branch = "master"
 category = "dev"
 level = 0
 potential_alternative_to = [ "GitHub Actions" ]
@@ -1529,6 +1705,7 @@ url = "https://github.com/YunoHost-Apps/forgejo_runner_ynh"
 
 [forte]
 added_date = 1737144206 # 2025/01/17
+branch = "master"
 category = "social_media"
 level = 7
 potential_alternative_to = [ "Facebook", "Threads", "Tumblr", "X" ]
@@ -1548,6 +1725,7 @@ url = "https://github.com/YunoHost-Apps/fossflow_ynh"
 
 [framaforms]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 0
 potential_alternative_to = [ "Google Forms" ]
@@ -1557,6 +1735,7 @@ url = "https://github.com/YunoHost-Apps/framaforms_ynh"
 
 [framagames]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 7
 state = "working"
@@ -1565,6 +1744,7 @@ url = "https://github.com/YunoHost-Apps/framagames_ynh"
 [freescout]
 added_date = 1700522075 # 2023/11/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Zendesk" ]
@@ -1574,6 +1754,7 @@ url = "https://github.com/YunoHost-Apps/freescout_ynh"
 
 [freshrss]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Feedly", "Google Reader", "Netvibes" ]
@@ -1583,6 +1764,7 @@ url = "https://github.com/YunoHost-Apps/freshrss_ynh"
 
 [friendica]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Facebook" ]
@@ -1600,6 +1782,7 @@ url = "https://github.com/YunoHost-Apps/ftpgrab_ynh"
 
 [funkwhale]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Deezer", "Soundcloud", "Spotify" ]
@@ -1619,6 +1802,7 @@ url = "https://github.com/YunoHost-Apps/fusion_ynh"
 
 [galene]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "BigBlueButton", "Skype", "Zoom" ]
@@ -1628,6 +1812,7 @@ url = "https://github.com/YunoHost-Apps/galene_ynh"
 
 [galette]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -1636,6 +1821,7 @@ url = "https://github.com/YunoHost-Apps/galette_ynh"
 
 [gamja]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -1644,6 +1830,7 @@ url = "https://github.com/YunoHost-Apps/gamja_ynh"
 
 [gancio]
 added_date = 1696575541 # 2023/10/06
+branch = "master"
 category = "social_media"
 level = 6
 state = "working"
@@ -1652,6 +1839,7 @@ url = "https://github.com/YunoHost-Apps/gancio_ynh"
 
 [garage]
 added_date = 1674656794 # 2023/01/25
+branch = "master"
 category = "system_tools"
 level = 3
 state = "working"
@@ -1660,6 +1848,7 @@ url = "https://github.com/YunoHost-Apps/garage_ynh"
 
 [garmin-to-fittrackee]
 added_date = 1744710102 # 2025/04/15
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -1667,6 +1856,7 @@ url = "https://github.com/YunoHost-Apps/garmin-to-fittrackee_ynh"
 
 [gemserv]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -1674,6 +1864,7 @@ url = "https://github.com/YunoHost-Apps/gemserv_ynh"
 
 [geoquest]
 added_date = 1736067457 # 2025/01/05
+branch = "master"
 category = "games"
 level = 7
 state = "working"
@@ -1682,6 +1873,7 @@ url = "https://github.com/YunoHost-Apps/geoquest_ynh"
 [getsimple]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -1692,6 +1884,7 @@ url = "https://github.com/YunoHost-Apps/getsimple_ynh"
 [ghost]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "arbitrary-limitations" ]
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -1700,6 +1893,7 @@ url = "https://github.com/YunoHost-Apps/ghost_ynh"
 
 [gitea]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "GitHub" ]
@@ -1709,6 +1903,7 @@ url = "https://github.com/YunoHost-Apps/gitea_ynh"
 
 [gitlab]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "GitHub" ]
@@ -1718,6 +1913,7 @@ url = "https://github.com/YunoHost-Apps/gitlab_ynh"
 
 [gitlab-runner]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -1726,6 +1922,7 @@ url = "https://github.com/YunoHost-Apps/gitlab-runner_ynh"
 
 [gitlist]
 added_date = 1675002183 # 2023/01/29
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -1734,6 +1931,7 @@ url = "https://github.com/YunoHost-Apps/gitlist_ynh"
 
 [glance]
 added_date = 1715979623 # 2024/05/17
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Netvibes" ]
@@ -1743,6 +1941,7 @@ url = "https://github.com/YunoHost-Apps/glance_ynh"
 
 [glances]
 added_date = 1742465549 # 2025/03/20
+branch = "master"
 category = "system_tools"
 level = 7
 potential_alternative_to = [ "StatusHub" ]
@@ -1752,6 +1951,7 @@ url = "https://github.com/YunoHost-Apps/glances_ynh"
 
 [glitchsoc]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 state = "working"
@@ -1760,6 +1960,7 @@ url = "https://github.com/YunoHost-Apps/glitchsoc_ynh"
 
 [glowingbear]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -1768,6 +1969,7 @@ url = "https://github.com/YunoHost-Apps/glowingbear_ynh"
 
 [glpi]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Cherwell", "Freshdesk", "Ivanti", "Peregrine Systems (AssetCenter)", "Remedy (BMC Software)", "ServiceNow" ]
@@ -1777,6 +1979,7 @@ url = "https://github.com/YunoHost-Apps/glpi_ynh"
 
 [gogs]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "GitHub" ]
@@ -1786,6 +1989,7 @@ url = "https://github.com/YunoHost-Apps/gogs_ynh"
 
 [gokapi]
 added_date = 1732047462 # 2024/11/19
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "WeTransfer" ]
@@ -1795,6 +1999,7 @@ url = "https://github.com/YunoHost-Apps/gokapi_ynh"
 
 [gomft]
 added_date = 1744710071 # 2025/04/15
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -1803,6 +2008,7 @@ url = "https://github.com/YunoHost-Apps/gomft_ynh"
 
 [gossa]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1810,6 +2016,7 @@ url = "https://github.com/YunoHost-Apps/gossa_ynh"
 
 [gotify]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -1818,6 +2025,7 @@ url = "https://github.com/YunoHost-Apps/gotify_ynh"
 [gotosocial]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-package" ]
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Akkoma", "Calckey", "Mastodon", "Misskey", "Pleroma", "Threads", "X" ]
@@ -1827,6 +2035,7 @@ url = "https://github.com/YunoHost-Apps/gotosocial_ynh"
 
 [grafana]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -1835,6 +2044,7 @@ url = "https://github.com/YunoHost-Apps/grafana_ynh"
 
 [grammalecte]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -1843,6 +2053,7 @@ url = "https://github.com/YunoHost-Apps/grammalecte_ynh"
 
 [grav]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Wix" ]
@@ -1852,6 +2063,7 @@ url = "https://github.com/YunoHost-Apps/grav_ynh"
 
 [grist]
 added_date = 1700230906 # 2023/11/17
+branch = "master"
 category = "office"
 level = 7
 potential_alternative_to = [ "Airtable" ]
@@ -1861,6 +2073,7 @@ url = "https://github.com/YunoHost-Apps/grist_ynh"
 
 [grocy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1868,6 +2081,7 @@ url = "https://github.com/YunoHost-Apps/grocy_ynh"
 
 [grr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -1875,6 +2089,7 @@ url = "https://github.com/YunoHost-Apps/grr_ynh"
 
 [guacamole]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -1882,6 +2097,7 @@ url = "https://github.com/YunoHost-Apps/guacamole_ynh"
 
 [gull]
 added_date = 1743282414 # 2025/03/29
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "bitly" ]
@@ -1891,6 +2107,7 @@ url = "https://github.com/YunoHost-Apps/gull_ynh"
 
 [h5ai]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1899,6 +2116,7 @@ url = "https://github.com/YunoHost-Apps/h5ai_ynh"
 [halcyon]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "bad-security-reputation", "deprecated-software" ]
+branch = "master"
 category = "social_media"
 deprecated_date = 1723889033 # 2024/08/17
 level = 6
@@ -1909,6 +2127,7 @@ url = "https://github.com/YunoHost-Apps/halcyon_ynh"
 
 [haste]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "Pastebin", "ZeroBin" ]
@@ -1918,6 +2137,7 @@ url = "https://github.com/YunoHost-Apps/haste_ynh"
 
 [hat]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -1925,6 +2145,7 @@ url = "https://github.com/YunoHost-Apps/hat_ynh"
 
 [headphones]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -1933,6 +2154,7 @@ url = "https://github.com/YunoHost-Apps/headphones_ynh"
 
 [headplane]
 added_date = 1731777819 # 2024/11/16
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -1941,6 +2163,7 @@ url = "https://github.com/YunoHost-Apps/headplane_ynh"
 
 [headscale]
 added_date = 1686503631 # 2023/06/11
+branch = "master"
 category = "system_tools"
 level = 8
 potential_alternative_to = [ "Tailscale" ]
@@ -1950,6 +2173,7 @@ url = "https://github.com/YunoHost-Apps/headscale_ynh"
 
 [hedgedoc]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Google Docs", "HackMD" ]
@@ -1959,6 +2183,7 @@ url = "https://github.com/YunoHost-Apps/hedgedoc_ynh"
 
 [helloworld]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 6
 state = "working"
@@ -1966,6 +2191,7 @@ url = "https://github.com/YunoHost-Apps/helloworld_ynh"
 
 [hextris]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -1973,6 +2199,7 @@ url = "https://github.com/YunoHost-Apps/hextris_ynh"
 
 [homarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -1980,6 +2207,7 @@ url = "https://github.com/YunoHost-Apps/homarr_ynh"
 
 [homeassistant]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -1987,6 +2215,7 @@ url = "https://github.com/YunoHost-Apps/homeassistant_ynh"
 
 [homebox]
 added_date = 1744736117 # 2025/04/15
+branch = "master"
 category = "small_utilities"
 level = 0
 state = "working"
@@ -1994,6 +2223,7 @@ url = "https://github.com/YunoHost-Apps/homebox_ynh"
 
 [horde]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 0
 state = "working"
@@ -2002,6 +2232,7 @@ url = "https://github.com/YunoHost-Apps/horde_ynh"
 
 [hotglue]
 added_date = 1722956791 # 2024/08/06
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Wordpress" ]
@@ -2010,6 +2241,7 @@ url = "https://github.com/YunoHost-Apps/hotglue_ynh"
 
 [hotspot]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -2018,6 +2250,7 @@ url = "https://github.com/labriqueinternet/hotspot_ynh"
 
 [httpsh]
 added_date = 1695759380 # 2023/09/26
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2025,6 +2258,7 @@ url = "https://github.com/Yunohost-Apps/httpsh_ynh"
 
 [hubzilla]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Facebook" ]
@@ -2034,6 +2268,7 @@ url = "https://github.com/YunoHost-Apps/hubzilla_ynh"
 
 [huginn]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -2041,6 +2276,7 @@ url = "https://github.com/YunoHost-Apps/huginn_ynh"
 
 [humhub]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -2048,6 +2284,7 @@ url = "https://github.com/yunohost-apps/humhub_ynh"
 
 [hydrogen]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -2056,6 +2293,7 @@ url = "https://github.com/YunoHost-Apps/hydrogen_ynh"
 
 [icecast2]
 added_date = 1730927086 # 2024/11/06
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -2063,6 +2301,7 @@ url = "https://github.com/YunoHost-Apps/icecast2_ynh"
 
 [iceshrimp]
 added_date = 1703341532 # 2023/12/23
+branch = "master"
 category = "social_media"
 level = 6
 potential_alternative_to = [ "Calckey", "Mastodon", "Misskey", "Pleroma", "Threads", "X" ]
@@ -2072,6 +2311,7 @@ url = "https://github.com/YunoHost-Apps/iceshrimp_ynh"
 
 [ifconfig-io]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2080,6 +2320,7 @@ url = "https://github.com/YunoHost-Apps/ifconfig-io_ynh"
 
 [ifm]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -2087,6 +2328,7 @@ url = "https://github.com/YunoHost-Apps/ifm_ynh"
 
 [ihatemoney]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "KittySplit", "Settle Up", "Splid", "Splitwise", "Tricount" ]
@@ -2097,6 +2339,7 @@ url = "https://github.com/YunoHost-Apps/ihatemoney_ynh"
 [immich]
 added_date = 1711921326 # 2024/03/31
 antifeatures = [ "alpha-software" ]
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -2104,6 +2347,7 @@ url = "https://github.com/YunoHost-Apps/immich_ynh"
 
 [incus]
 added_date = 1710508401 # 2024/03/15
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2111,6 +2355,7 @@ url = "https://github.com/YunoHost-Apps/incus_ynh"
 
 [indexhibit]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -2119,6 +2364,7 @@ url = "https://github.com/YunoHost-Apps/indexhibit_ynh"
 
 [indico]
 added_date = 1731959960 # 2024/11/18
+branch = "master"
 category = "communication"
 level = 6
 potential_alternative_to = [ "Zoho Backstage" ]
@@ -2128,6 +2374,7 @@ url = "https://github.com/YunoHost-Apps/indico_ynh"
 
 [influxdb_v2]
 added_date = 1691920584 # 2023/08/13
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2137,6 +2384,7 @@ url = "https://github.com/YunoHost-Apps/influxdb_v2_ynh"
 [invidious]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "YouTube" ]
@@ -2146,6 +2394,7 @@ url = "https://github.com/YunoHost-Apps/invidious_ynh"
 
 [invoiceninja5]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -2153,6 +2402,7 @@ url = "https://github.com/YunoHost-Apps/invoiceninja5_ynh"
 
 [invoiceshelf]
 added_date = 1738685867 # 2025/02/04
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -2161,6 +2411,7 @@ url = "https://github.com/YunoHost-Apps/invoiceshelf_ynh"
 
 [isso]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -2169,6 +2420,7 @@ url = "https://github.com/YunoHost-Apps/isso_ynh"
 
 [it-tools]
 added_date = 1728359796 # 2024/10/08
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -2176,6 +2428,7 @@ url = "https://github.com/YunoHost-Apps/it-tools_ynh"
 
 [itflow]
 added_date = 1696579498 # 2023/10/06
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -2184,6 +2437,7 @@ url = "https://github.com/YunoHost-Apps/itflow_ynh"
 
 [jackett]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -2191,6 +2445,7 @@ url = "https://github.com/YunoHost-Apps/jackett_ynh"
 
 [jangouts]
 added_date = 1739112385 # 2025/02/09
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Google Hangouts", "Skype" ]
@@ -2200,6 +2455,7 @@ url = "https://github.com/YunoHost-Apps/jangouts_ynh"
 
 [jeedom]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 0
 state = "working"
@@ -2207,6 +2463,7 @@ url = "https://github.com/YunoHost-Apps/jeedom_ynh"
 
 [jellyfin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Netflix", "Plex" ]
@@ -2216,6 +2473,7 @@ url = "https://github.com/YunoHost-Apps/jellyfin_ynh"
 
 [jellyfin-vue]
 added_date = 1694251217 # 2023/09/09
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Netflix", "Plex" ]
@@ -2225,6 +2483,7 @@ url = "https://github.com/YunoHost-Apps/jellyfin-vue_ynh"
 
 [jellyseerr]
 added_date = 1683832079 # 2023/05/11
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Overseerr" ]
@@ -2233,6 +2492,7 @@ url = "https://github.com/YunoHost-Apps/jellyseerr_ynh"
 
 [jenkins]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -2240,6 +2500,7 @@ url = "https://github.com/YunoHost-Apps/jenkins_ynh"
 
 [jirafeau]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "ImageShack", "Imgur" ]
@@ -2249,6 +2510,7 @@ url = "https://github.com/YunoHost-Apps/jirafeau_ynh"
 
 [jitsi]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Google Hangouts", "Skype" ]
@@ -2259,6 +2521,7 @@ url = "https://github.com/YunoHost-Apps/jitsi_ynh"
 [joomla]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -2267,6 +2530,7 @@ url = "https://github.com/YunoHost-Apps/joomla_ynh"
 
 [joplin]
 added_date = 1702203874 # 2023/12/10
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -2275,6 +2539,7 @@ url = "https://github.com/YunoHost-Apps/joplin_ynh"
 
 [jsoncrack]
 added_date = 1732845261 # 2024/11/29
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -2282,6 +2547,7 @@ url = "https://github.com/YunoHost-Apps/jsoncrack_ynh"
 
 [jump]
 added_date = 1714286036 # 2024/04/28
+branch = "master"
 category = "productivity_and_management"
 level = 0
 potential_alternative_to = [ "Dashy", "Heimdall" ]
@@ -2290,6 +2556,7 @@ url = "https://github.com/YunoHost-Apps/jump_ynh"
 
 [jupyterlab]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 0
 state = "working"
@@ -2298,6 +2565,7 @@ url = "https://github.com/YunoHost-Apps/jupyterlab_ynh"
 
 [kanboard]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Trello" ]
@@ -2317,6 +2585,7 @@ url = "https://github.com/YunoHost-Apps/karakeep_ynh"
 [kavita]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "paid-content" ]
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -2325,6 +2594,7 @@ url = "https://github.com/YunoHost-Apps/kavita_ynh"
 
 [keeweb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "1Password", "Dashlane", "Enpass", "LastPass" ]
@@ -2334,6 +2604,7 @@ url = "https://github.com/YunoHost-Apps/keeweb_ynh"
 
 [khatru-pyramid]
 added_date = 1729073927 # 2024/10/16
+branch = "master"
 category = "social_media"
 level = 6
 potential_alternative_to = [ "Mastodon", "Twitter" ]
@@ -2342,6 +2613,7 @@ url = "https://github.com/YunoHost-Apps/khatru-pyramid_ynh"
 
 [kimai2]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Hamster", "RescueTime", "Toggl Track" ]
@@ -2351,6 +2623,7 @@ url = "https://github.com/YunoHost-Apps/kimai2_ynh"
 
 [kiwiirc]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -2359,6 +2632,7 @@ url = "https://github.com/YunoHost-Apps/kiwiirc_ynh"
 
 [kiwix]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -2366,6 +2640,7 @@ url = "https://github.com/YunoHost-Apps/kiwix_ynh"
 
 [kodi]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 potential_alternative_to = [ "Netflix", "Plex", "QuickTime", "Windows Media Center", "Windows Media Player" ]
@@ -2375,6 +2650,7 @@ url = "https://github.com/YunoHost-Apps/kodi_ynh"
 
 [koel]
 added_date = 1694978602 # 2023/09/17
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Airsonic", "Deezer", "SoundCloud", "Spotify" ]
@@ -2384,6 +2660,7 @@ url = "https://github.com/YunoHost-Apps/koel_ynh"
 
 [komga]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -2392,6 +2669,7 @@ url = "https://github.com/YunoHost-Apps/komga_ynh"
 
 [kresus]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Bankin", "Budgea", "Linxo", "Microsoft Money", "Mint", "You Need A Budget" ]
@@ -2401,6 +2679,7 @@ url = "https://github.com/YunoHost-Apps/kresus_ynh"
 
 [ladder]
 added_date = 1702560857 # 2023/12/14
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "12ft", "13ft" ]
@@ -2409,6 +2688,7 @@ url = "https://github.com/YunoHost-Apps/ladder_ynh"
 
 [languagetool]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -2428,6 +2708,7 @@ url = "https://github.com/YunoHost-Apps/lasuite-docs_ynh"
 [laverna]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software", "package-not-maintained" ]
+branch = "master"
 category = "office"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -2437,6 +2718,7 @@ url = "https://github.com/YunoHost-Apps/laverna_ynh"
 
 [leantime]
 added_date = 1683586765 # 2023/05/08
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Asana", "ClickUp", "Notion" ]
@@ -2446,6 +2728,7 @@ url = "https://github.com/YunoHost-Apps/leantime_ynh"
 
 [leed]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 6
 potential_alternative_to = [ "Feedly", "Google Reader", "Netvibes" ]
@@ -2455,6 +2738,7 @@ url = "https://github.com/YunoHost-Apps/leed_ynh"
 
 [lemmy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Hacker News", "Lobste.rs", "Reddit" ]
@@ -2464,6 +2748,7 @@ url = "https://github.com/YunoHost-Apps/lemmy_ynh"
 [librarian]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "social_media"
 deprecated_date = 1707947485 # 2024/02/14
 level = 7
@@ -2474,6 +2759,7 @@ url = "https://github.com/YunoHost-Apps/librarian_ynh"
 [libreerp]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "paid-content" ]
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -2482,6 +2768,7 @@ url = "https://github.com/YunoHost-Apps/libreerp_ynh"
 
 [libremdb]
 added_date = 1681904233 # 2023/04/19
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "IMDb" ]
@@ -2490,6 +2777,7 @@ url = "https://github.com/YunoHost-Apps/libremdb_ynh"
 
 [librephotos]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 potential_alternative_to = [ "Google Photos" ]
@@ -2499,6 +2787,7 @@ url = "https://github.com/YunoHost-Apps/librephotos_ynh"
 
 [librespeed]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2508,6 +2797,7 @@ url = "https://github.com/YunoHost-Apps/librespeed_ynh"
 [libreto]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -2517,6 +2807,7 @@ url = "https://github.com/YunoHost-Apps/libreto_ynh"
 
 [libretranslate]
 added_date = 1680436289 # 2023/04/02
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "DeepL", "Google Translate" ]
@@ -2525,6 +2816,7 @@ url = "https://github.com/YunoHost-Apps/libretranslate_ynh"
 
 [librex]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -2532,6 +2824,7 @@ url = "https://github.com/YunoHost-Apps/librex_ynh"
 
 [lichenmarkdown]
 added_date = 1732569086 # 2024/11/25
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -2539,6 +2832,7 @@ url = "https://github.com/YunoHost-Apps/lichenmarkdown_ynh"
 
 [lidarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -2546,6 +2840,7 @@ url = "https://github.com/YunoHost-Apps/lidarr_ynh"
 
 [limesurvey]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Google Forms", "SurveyMonkey" ]
@@ -2556,6 +2851,7 @@ url = "https://github.com/YunoHost-Apps/limesurvey_ynh"
 [lingva]
 added_date = 1685604095 # 2023/06/01
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -2563,6 +2859,7 @@ url = "https://github.com/YunoHost-Apps/lingva_ynh"
 
 [linkstack]
 added_date = 1683443449 # 2023/05/07
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -2570,6 +2867,7 @@ url = "https://github.com/YunoHost-Apps/linkstack_ynh"
 
 [linkwarden]
 added_date = 1729028717 # 2024/10/15
+branch = "master"
 category = "reading"
 level = 7
 potential_alternative_to = [ "Pocket", "Shaarli", "Wallabag" ]
@@ -2579,6 +2877,7 @@ url = "https://github.com/YunoHost-Apps/linkwarden_ynh"
 [linuxdash]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "system_tools"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -2588,6 +2887,7 @@ url = "https://github.com/YunoHost-Apps/linuxdash_ynh"
 
 [lionwiki-t2t]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -2596,6 +2896,7 @@ url = "https://github.com/YunoHost-Apps/lionwiki-t2t_ynh"
 
 [listmonk]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Google Groups" ]
@@ -2614,6 +2915,7 @@ url = "https://github.com/YunoHost-Apps/litechat_ynh"
 
 [localai]
 added_date = 1737535566 # 2025/01/22
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -2621,6 +2923,7 @@ url = "https://github.com/YunoHost-Apps/localai_ynh"
 
 [logdy]
 added_date = 1729498404 # 2024/10/21
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -2629,6 +2932,7 @@ url = "https://github.com/YunoHost-Apps/logdy_ynh"
 
 [loki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2637,6 +2941,7 @@ url = "https://github.com/YunoHost-Apps/loki_ynh"
 
 [lstu]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "bitly" ]
@@ -2647,6 +2952,7 @@ url = "https://github.com/YunoHost-Apps/lstu_ynh"
 [luckysheet]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "office"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -2657,6 +2963,7 @@ url = "https://github.com/YunoHost-Apps/luckysheet_ynh"
 
 [lufi]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "WeTransfer" ]
@@ -2666,6 +2973,7 @@ url = "https://github.com/YunoHost-Apps/lufi_ynh"
 
 [lutim]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 6
 potential_alternative_to = [ "ImageShack", "Imgur" ]
@@ -2675,6 +2983,7 @@ url = "https://github.com/YunoHost-Apps/lutim_ynh"
 
 [lxd]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -2682,6 +2991,7 @@ url = "https://github.com/YunoHost-Apps/lxd_ynh"
 
 [lxd-dashboard]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2690,6 +3000,7 @@ url = "https://github.com/YunoHost-Apps/lxd-dashboard_ynh"
 [lychee]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "paid-content" ]
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Flickr", "Google Photos" ]
@@ -2699,6 +3010,7 @@ url = "https://github.com/YunoHost-Apps/lychee_ynh"
 
 [mailman3]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 potential_alternative_to = [ "Google Groups" ]
@@ -2708,6 +3020,7 @@ url = "https://github.com/YunoHost-Apps/mailman3_ynh"
 
 [mantis]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -2716,6 +3029,7 @@ url = "https://github.com/YunoHost-Apps/mantis_ynh"
 
 [many-notes]
 added_date = 1744920684 # 2025/04/17
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -2723,6 +3037,7 @@ url = "https://github.com/YunoHost-Apps/many-notes_ynh"
 
 [marl]
 added_date = 1733696598 # 2024/12/08
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -2730,6 +3045,7 @@ url = "https://github.com/YunoHost-Apps/marl_ynh"
 
 [mastodon]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "X" ]
@@ -2739,6 +3055,7 @@ url = "https://github.com/YunoHost-Apps/mastodon_ynh"
 
 [matomo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Google Analytics", "Xiti" ]
@@ -2748,6 +3065,7 @@ url = "https://github.com/YunoHost-Apps/matomo_ynh"
 
 [matrix-appservice-irc]
 added_date = 1675621561 # 2023/02/05
+branch = "master"
 category = "communication"
 level = 0
 state = "working"
@@ -2756,6 +3074,7 @@ url = "https://github.com/YunoHost-Apps/matrix-appservice-irc_ynh"
 
 [matterbridge]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -2764,6 +3083,7 @@ url = "https://github.com/YunoHost-Apps/matterbridge_ynh"
 
 [mattermost]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Slack" ]
@@ -2773,6 +3093,7 @@ url = "https://github.com/YunoHost-Apps/mattermost_ynh"
 
 [mautic]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Marketo", "NetResult", "SalesFusion" ]
@@ -2782,6 +3103,7 @@ url = "https://github.com/YunoHost-Apps/mautic_ynh"
 
 [mautrix_discord]
 added_date = 1707659042 # 2024/02/11
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Discord" ]
@@ -2792,6 +3114,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_discord_ynh"
 [mautrix_facebook]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "communication"
 deprecated_date = 1709661665 # 2024/03/05
 level = 0
@@ -2802,6 +3125,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_facebook_ynh"
 
 [mautrix_signal]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 potential_alternative_to = [ "Signal" ]
@@ -2811,6 +3135,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_signal_ynh"
 
 [mautrix_telegram]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 0
 potential_alternative_to = [ "Telegram" ]
@@ -2820,6 +3145,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_telegram_ynh"
 
 [mautrix_whatsapp]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Whatsapp" ]
@@ -2829,6 +3155,7 @@ url = "https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh"
 
 [mediatracker]
 added_date = 1740934673 # 2025/03/02
+branch = "master"
 category = "multimedia"
 level = 0
 state = "working"
@@ -2836,6 +3163,7 @@ url = "https://github.com/YunoHost-Apps/mediatracker_ynh"
 
 [mediawiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -2844,6 +3172,7 @@ url = "https://github.com/YunoHost-Apps/mediawiki_ynh"
 
 [meilisearch]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -2852,6 +3181,7 @@ url = "https://github.com/YunoHost-Apps/meilisearch_ynh"
 
 [memos]
 added_date = 1744663769 # 2025/04/14
+branch = "master"
 category = "office"
 level = 7
 state = "working"
@@ -2860,6 +3190,7 @@ url = "https://github.com/YunoHost-Apps/memos_ynh"
 
 [metabase]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -2868,6 +3199,7 @@ url = "https://github.com/YunoHost-Apps/metabase_ynh"
 
 [metronome]
 added_date = 1730230504 # 2024/10/29
+branch = "master"
 category = "communication"
 level = 7
 state = "working"
@@ -2876,6 +3208,7 @@ url = "https://github.com/YunoHost-Apps/metronome_ynh"
 
 [microbin]
 added_date = 1712237414 # 2024/04/04
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -2884,6 +3217,7 @@ url = "https://github.com/YunoHost-Apps/microbin_ynh"
 
 [microblogpub]
 added_date = 1717921017 # 2024/06/09
+branch = "master"
 category = "social_media"
 level = 6
 state = "working"
@@ -2893,6 +3227,7 @@ url = "https://github.com/YunoHost-Apps/microblogpub_ynh"
 [minchat]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "communication"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -2903,6 +3238,7 @@ url = "https://github.com/YunoHost-Apps/minchat_ynh"
 [mindmaps]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "office"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -2912,6 +3248,7 @@ url = "https://github.com/YunoHost-Apps/mindmaps_ynh"
 
 [minetest]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 8
 potential_alternative_to = [ "Minecraft" ]
@@ -2921,6 +3258,7 @@ url = "https://github.com/YunoHost-Apps/minetest_ynh"
 [mineweb]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -2929,6 +3267,7 @@ url = "https://github.com/YunoHost-Apps/mineweb_ynh"
 
 [minidlna]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 6
 state = "working"
@@ -2937,6 +3276,7 @@ url = "https://github.com/YunoHost-Apps/minidlna_ynh"
 
 [miniflux]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Feedly", "Google Reader", "Netvibes" ]
@@ -2946,6 +3286,7 @@ url = "https://github.com/YunoHost-Apps/miniflux_ynh"
 
 [minio]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "Dropbox", "Google Drive", "Mega", "Microsoft OneDrive" ]
@@ -2954,6 +3295,7 @@ url = "https://github.com/YunoHost-Apps/minio_ynh"
 
 [mirotalk]
 added_date = 1730110998 # 2024/10/28
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "BigBlueButton", "Skype", "Zoom" ]
@@ -2963,6 +3305,7 @@ url = "https://github.com/YunoHost-Apps/mirotalk_ynh"
 
 [misskey]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 state = "working"
@@ -2971,6 +3314,7 @@ url = "https://github.com/YunoHost-Apps/misskey_ynh"
 
 [mitra]
 added_date = 1730913143 # 2024/11/06
+branch = "master"
 category = "social_media"
 level = 7
 potential_alternative_to = [ "Bluesky", "Threads", "Twitter" ]
@@ -2980,6 +3324,7 @@ url = "https://github.com/YunoHost-Apps/mitra_ynh"
 
 [mlmmj]
 added_date = 1724866653 # 2024/08/28
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -2988,6 +3333,7 @@ url = "https://github.com/YunoHost-Apps/mlmmj_ynh"
 
 [mlmmj-web]
 added_date = 1725089381 # 2024/08/31
+branch = "master"
 category = "communication"
 level = 7
 state = "working"
@@ -2996,6 +3342,7 @@ url = "https://github.com/YunoHost-Apps/mlmmj-web_ynh"
 
 [mobilizon]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Eventbrite", "Facebook", "Meetup" ]
@@ -3005,6 +3352,7 @@ url = "https://github.com/YunoHost-Apps/mobilizon_ynh"
 
 [mollysocket]
 added_date = 1729641185 # 2024/10/22
+branch = "master"
 category = "communication"
 level = 7
 state = "working"
@@ -3013,6 +3361,7 @@ url = "https://github.com/YunoHost-Apps/mollysocket_ynh"
 
 [moncycle]
 added_date = 1674505944 # 2023/01/23
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -3029,6 +3378,7 @@ url = "https://github.com/YunoHost-Apps/mongo-express_ynh"
 
 [monica]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -3036,6 +3386,7 @@ url = "https://github.com/YunoHost-Apps/monica_ynh"
 
 [monitorix]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3044,6 +3395,7 @@ url = "https://github.com/YunoHost-Apps/monitorix_ynh"
 
 [moodle]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 potential_alternative_to = [ "Dokeos" ]
@@ -3052,6 +3404,7 @@ url = "https://github.com/YunoHost-Apps/moodle_ynh"
 
 [mopidy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 state = "working"
@@ -3060,6 +3413,7 @@ url = "https://github.com/YunoHost-Apps/mopidy_ynh"
 
 [mosquitto]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 0
 state = "working"
@@ -3067,6 +3421,7 @@ url = "https://github.com/YunoHost-Apps/mosquitto_ynh"
 
 [mostlymatter]
 added_date = 1738689693 # 2025/02/04
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Slack" ]
@@ -3076,6 +3431,7 @@ url = "https://github.com/YunoHost-Apps/mostlymatter_ynh"
 
 [motioneye]
 added_date = 1705503211 # 2024/01/17
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -3083,6 +3439,7 @@ url = "https://github.com/YunoHost-Apps/motioneye_ynh"
 
 [movim]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Facebook Messenger", "Facebook", "MSN" ]
@@ -3092,6 +3449,7 @@ url = "https://github.com/YunoHost-Apps/movim_ynh"
 
 [mstream]
 added_date = 1683054560 # 2023/05/02
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Anchor", "Deezer", "SoundCloud", "Spotify" ]
@@ -3102,6 +3460,7 @@ url = "https://github.com/YunoHost-Apps/mstream_ynh"
 [mumble-web]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "communication"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -3111,6 +3470,7 @@ url = "https://github.com/YunoHost-Apps/mumble-web_ynh"
 
 [mumbleserver]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -3119,6 +3479,7 @@ url = "https://github.com/YunoHost-Apps/mumbleserver_ynh"
 
 [my-mind]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -3127,6 +3488,7 @@ url = "https://github.com/YunoHost-Apps/my-mind_ynh"
 
 [my_capsule]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3134,6 +3496,7 @@ url = "https://github.com/YunoHost-Apps/my_capsule_ynh"
 
 [my_webapp]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3142,6 +3505,7 @@ url = "https://github.com/YunoHost-Apps/my_webapp_ynh"
 
 [my_webdav]
 added_date = 1722234218 # 2024/07/29
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3149,6 +3513,7 @@ url = "https://github.com/YunoHost-Apps/my_webdav_ynh"
 
 [mybb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 state = "working"
@@ -3157,6 +3522,7 @@ url = "https://github.com/YunoHost-Apps/mybb_ynh"
 
 [mydrive]
 added_date = 1742415452 # 2025/03/19
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "Apple iCloud", "Dropbox", "Google Drive", "Microsoft OneDrive" ]
@@ -3166,6 +3532,7 @@ url = "https://github.com/YunoHost-Apps/mydrive_ynh"
 
 [mygpo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 state = "working"
@@ -3174,6 +3541,7 @@ url = "https://github.com/YunoHost-Apps/mygpo_ynh"
 
 [myspeed]
 added_date = 1728990584 # 2024/10/15
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3182,6 +3550,7 @@ url = "https://github.com/YunoHost-Apps/myspeed_ynh"
 
 [mytinytodo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -3191,6 +3560,7 @@ url = "https://github.com/YunoHost-Apps/mytinytodo_ynh"
 [n8n]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -3198,6 +3568,7 @@ url = "https://github.com/YunoHost-Apps/n8n_ynh"
 
 [navidrome]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -3207,6 +3578,7 @@ url = "https://github.com/YunoHost-Apps/navidrome_ynh"
 [netdata]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3223,6 +3595,7 @@ url = "https://gitlab.domainepublic.net/Neutrinet/neutrinet_ynh"
 
 [nextcloud]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Apple iCloud", "Dropbox", "Google Apps", "Google Docs", "Google Drive", "Mega", "Microsoft OneDrive" ]
@@ -3232,6 +3605,7 @@ url = "https://github.com/YunoHost-Apps/nextcloud_ynh"
 
 [nextcloud-signaling]
 added_date = 1728398733 # 2024/10/08
+branch = "master"
 category = "communication"
 level = 0
 potential_alternative_to = [ "BBB", "Big Blue Button", "Jitsi", "Microsoft Teams", "Skype", "Zoom" ]
@@ -3242,6 +3616,7 @@ url = "https://github.com/YunoHost-Apps/nextcloud-signaling_ynh"
 [nitter]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "X" ]
@@ -3251,6 +3626,7 @@ url = "https://github.com/YunoHost-Apps/nitter_ynh"
 
 [noalyss]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 6
 potential_alternative_to = [ "Exact Online", "WinBooks", "Yooz" ]
@@ -3260,6 +3636,7 @@ url = "https://github.com/YunoHost-Apps/noalyss_ynh"
 
 [nocodb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "Airtable" ]
@@ -3268,6 +3645,7 @@ url = "https://github.com/YunoHost-Apps/nocodb_ynh"
 
 [node_exporter]
 added_date = 1740665024 # 2025/02/27
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3276,6 +3654,7 @@ url = "https://github.com/YunoHost-Apps/node_exporter_ynh"
 
 [nodebb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -3284,6 +3663,7 @@ url = "https://github.com/YunoHost-Apps/nodebb_ynh"
 
 [nodered]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -3291,6 +3671,7 @@ url = "https://github.com/YunoHost-Apps/nodered_ynh"
 
 [nomad]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 1
 state = "working"
@@ -3298,6 +3679,7 @@ url = "https://github.com/YunoHost-Apps/nomad_ynh"
 
 [ntfy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -3305,6 +3687,7 @@ url = "https://github.com/YunoHost-Apps/ntfy_ynh"
 
 [nullboard]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -3313,6 +3696,7 @@ url = "https://github.com/YunoHost-Apps/nullboard_ynh"
 
 [octoprint]
 added_date = 1708461644 # 2024/02/20
+branch = "master"
 category = "iot"
 level = 0
 state = "notworking"
@@ -3320,6 +3704,7 @@ url = "https://github.com/YunoHost-Apps/octoprint_ynh"
 
 [ofbiz]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -3328,6 +3713,7 @@ url = "https://github.com/YunoHost-Apps/ofbiz_ynh"
 
 [ojs]
 added_date = 1728387811 # 2024/10/08
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -3336,6 +3722,7 @@ url = "https://github.com/YunoHost-Apps/ojs_ynh"
 
 [olivetin]
 added_date = 1718743911 # 2024/06/18
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3351,6 +3738,7 @@ url = "https://github.com/YunoHost-Apps/ollama_ynh"
 
 [ombi]
 added_date = 1696432145 # 2023/10/04
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Netflix", "Plex" ]
@@ -3360,6 +3748,7 @@ url = "https://github.com/YunoHost-Apps/ombi_ynh"
 
 [omeka-s]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -3368,6 +3757,7 @@ url = "https://github.com/YunoHost-Apps/omeka-s_ynh"
 
 [onlyoffice]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Google Docs", "Microsoft Excel", "Microsoft Office", "Microsoft PowerPoint", "Microsoft Word" ]
@@ -3377,6 +3767,7 @@ url = "https://github.com/YunoHost-Apps/onlyoffice_ynh"
 
 [opcache-gui]
 added_date = 1738833322 # 2025/02/06
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3384,6 +3775,7 @@ url = "https://github.com/YunoHost-Apps/opcache-gui_ynh"
 
 [open-web-calendar]
 added_date = 1707573007 # 2024/02/10
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Google Agenda", "Microsoft Outlook" ]
@@ -3393,6 +3785,7 @@ url = "https://github.com/YunoHost-Apps/open-web-calendar_ynh"
 
 [opencloud]
 added_date = 1740568746 # 2025/02/26
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "Apple iCloud", "Dropbox", "Google Drive", "Microsoft OneDrive" ]
@@ -3411,6 +3804,7 @@ url = "https://github.com/YunoHost-Apps/openemr_ynh"
 [opennote]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "office"
 deprecated_date = 1708403676 # 2024/02/20
 level = 6
@@ -3420,6 +3814,7 @@ url = "https://github.com/YunoHost-Apps/opennote_ynh"
 
 [openproject]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 7
 potential_alternative_to = [ "Asaana", "Basecamp", "Monday" ]
@@ -3428,6 +3823,7 @@ url = "https://github.com/YunoHost-Apps/openproject_ynh"
 
 [opensearch]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "ElasticSearch" ]
@@ -3437,6 +3833,7 @@ url = "https://github.com/YunoHost-Apps/opensearch_ynh"
 
 [opensondage]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Doodle" ]
@@ -3446,6 +3843,7 @@ url = "https://github.com/YunoHost-Apps/opensondage_ynh"
 
 [opentracker]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 0
 state = "working"
@@ -3453,6 +3851,7 @@ url = "https://github.com/YunoHost-Apps/opentracker_ynh"
 
 [orangehrm]
 added_date = 1740300408 # 2025/02/23
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -3461,6 +3860,7 @@ url = "https://github.com/YunoHost-Apps/orangehrm_ynh"
 [osjs]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "wat"
 deprecated_date = 1712777448 # 2024/04/10
 level = 0
@@ -3469,6 +3869,7 @@ url = "https://github.com/YunoHost-Apps/osjs_ynh"
 
 [osticket]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -3477,6 +3878,7 @@ url = "https://github.com/YunoHost-Apps/osticket_ynh"
 [outline]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3485,6 +3887,7 @@ url = "https://github.com/YunoHost-Apps/outline_ynh"
 
 [overleaf]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -3493,6 +3896,7 @@ url = "https://github.com/YunoHost-Apps/overleaf_ynh"
 
 [owncast]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -3500,6 +3904,7 @@ url = "https://github.com/YunoHost-Apps/owncast_ynh"
 
 [owncast-emojiwall]
 added_date = 1696593645 # 2023/10/06
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -3507,6 +3912,7 @@ url = "https://github.com/YunoHost-Apps/owncast-emojiwall_ynh"
 
 [owncloud]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Apple iCloud", "Dropbox", "Google Drive", "Microsoft OneDrive" ]
@@ -3516,6 +3922,7 @@ url = "https://github.com/YunoHost-Apps/owncloud_ynh"
 
 [owntracks]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 0
 state = "notworking"
@@ -3523,6 +3930,7 @@ url = "https://github.com/YunoHost-Apps/owntracks_ynh"
 
 [pagure]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 0
 state = "notworking"
@@ -3531,6 +3939,7 @@ url = "https://github.com/YunoHost-Apps/pagure_ynh"
 
 [paheko]
 added_date = 1675849640 # 2023/02/08
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Ciel Associations" ]
@@ -3540,6 +3949,7 @@ url = "https://github.com/YunoHost-Apps/paheko_ynh"
 
 [pairdrop]
 added_date = 1696857595 # 2023/10/09
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "AirDrop" ]
@@ -3549,6 +3959,7 @@ url = "https://github.com/YunoHost-Apps/pairdrop_ynh"
 
 [paperless-ngx]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 state = "working"
@@ -3557,6 +3968,7 @@ url = "https://github.com/YunoHost-Apps/paperless-ngx_ynh"
 
 [passed]
 added_date = 1743846139 # 2025/04/05
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "Pastebin" ]
@@ -3566,6 +3978,7 @@ url = "https://github.com/YunoHost-Apps/passed_ynh"
 
 [peachpub]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Facebook", "Instagram" ]
@@ -3574,6 +3987,7 @@ url = "https://github.com/YunoHost-Apps/peachpub_ynh"
 
 [peer-calls]
 added_date = 1729499902 # 2024/10/21
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "BigBlueButton", "Skype", "Zoom" ]
@@ -3583,6 +3997,7 @@ url = "https://github.com/YunoHost-Apps/peer-calls_ynh"
 
 [peertube]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Dailymotion", "Twitch", "Vimeo", "YouTube" ]
@@ -3593,6 +4008,7 @@ url = "https://github.com/YunoHost-Apps/peertube_ynh"
 [peertube-search-index]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "social_media"
 level = 6
 state = "working"
@@ -3601,6 +4017,7 @@ url = "https://github.com/YunoHost-Apps/peertube-search-index_ynh"
 
 [peertube_remote_runner]
 added_date = 1688894207 # 2023/07/09
+branch = "master"
 category = "social_media"
 level = 8
 state = "working"
@@ -3609,6 +4026,7 @@ url = "https://github.com/YunoHost-Apps/peertube_remote_runner_ynh"
 
 [pelican]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -3617,6 +4035,7 @@ url = "https://github.com/YunoHost-Apps/pelican_ynh"
 
 [penpot]
 added_date = 1708540527 # 2024/02/21
+branch = "master"
 category = "dev"
 level = 7
 state = "working"
@@ -3625,6 +4044,7 @@ url = "https://github.com/YunoHost-Apps/penpot_ynh"
 
 [pepettes]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 7
 state = "working"
@@ -3633,6 +4053,7 @@ url = "https://github.com/YunoHost-Apps/pepettes_ynh"
 
 [petitesannonces]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -3641,6 +4062,7 @@ url = "https://github.com/YunoHost-Apps/petitesannonces_ynh"
 
 [petrolette]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Netvibes" ]
@@ -3650,6 +4072,7 @@ url = "https://github.com/YunoHost-Apps/petrolette_ynh"
 
 [pgadmin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3658,6 +4081,7 @@ url = "https://github.com/YunoHost-Apps/pgadmin_ynh"
 
 [pgweb]
 added_date = 1725620686 # 2024/09/06
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3666,6 +4090,7 @@ url = "https://github.com/YunoHost-Apps/pgweb_ynh"
 
 [phanpy]
 added_date = 1731399581 # 2024/11/12
+branch = "master"
 category = "social_media"
 level = 7
 potential_alternative_to = [ "Bluesky", "Mastodon", "Threads", "Twitter", "X" ]
@@ -3676,6 +4101,7 @@ url = "https://github.com/YunoHost-Apps/phanpy_ynh"
 [photonix]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "multimedia"
 level = 0
 state = "notworking"
@@ -3685,6 +4111,7 @@ url = "https://github.com/YunoHost-Apps/photonix_ynh"
 [photoprism]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "paid-content" ]
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -3693,6 +4120,7 @@ url = "https://github.com/YunoHost-Apps/photoprism_ynh"
 
 [photoview]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -3701,6 +4129,7 @@ url = "https://github.com/YunoHost-Apps/photoview_ynh"
 
 [phpback]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 0
 state = "notworking"
@@ -3708,6 +4137,7 @@ url = "https://github.com/YunoHost-Apps/phpback_ynh"
 
 [phpbb]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 0
 state = "working"
@@ -3716,6 +4146,7 @@ url = "https://github.com/YunoHost-Apps/phpbb_ynh"
 
 [phpboost]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3723,6 +4154,7 @@ url = "https://github.com/YunoHost-Apps/phpboost_ynh"
 
 [phpinfo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3730,6 +4162,7 @@ url = "https://github.com/YunoHost-Apps/phpinfo_ynh"
 
 [phpipam]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -3737,6 +4170,7 @@ url = "https://github.com/YunoHost-Apps/phpipam_ynh"
 
 [phpldapadmin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3745,6 +4179,7 @@ url = "https://github.com/YunoHost-Apps/phpldapadmin_ynh"
 
 [phplicensewatcher]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3752,6 +4187,7 @@ url = "https://github.com/YunoHost-Apps/phplicensewatcher_ynh"
 
 [phpmyadmin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3760,6 +4196,7 @@ url = "https://github.com/YunoHost-Apps/phpmyadmin_ynh"
 
 [phpservermon]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -3768,6 +4205,7 @@ url = "https://github.com/YunoHost-Apps/phpservermon_ynh"
 
 [phpsysinfo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3777,6 +4215,7 @@ url = "https://github.com/YunoHost-Apps/phpsysinfo_ynh"
 [pico]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -3787,6 +4226,7 @@ url = "https://github.com/YunoHost-Apps/pico_ynh"
 [pihole]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -3795,6 +4235,7 @@ url = "https://github.com/YunoHost-Apps/pihole_ynh"
 
 [pinkarrows]
 added_date = 1726562931 # 2024/09/17
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "Skitch" ]
@@ -3804,6 +4245,7 @@ url = "https://github.com/YunoHost-Apps/pinkarrows_ynh"
 [piped]
 added_date = 1706558247 # 2024/01/29
 antifeatures = [ "non-free-network" ]
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "YouTube" ]
@@ -3813,6 +4255,7 @@ url = "https://github.com/YunoHost-Apps/piped_ynh"
 
 [piwigo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 7
 potential_alternative_to = [ "Google Photos", "Keepeek", "Koken", "Orkis Ajaris", "Orphéa" ]
@@ -3822,6 +4265,7 @@ url = "https://github.com/YunoHost-Apps/piwigo_ynh"
 
 [pixelfed]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Instagram" ]
@@ -3831,6 +4275,7 @@ url = "https://github.com/YunoHost-Apps/pixelfed_ynh"
 
 [pixelfedglitch]
 added_date = 1739652110 # 2025/02/15
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "Instagram", "Pixelfed" ]
@@ -3840,6 +4285,7 @@ url = "https://github.com/YunoHost-Apps/pixelfedglitch_ynh"
 
 [plainpad]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -3848,6 +4294,7 @@ url = "https://github.com/YunoHost-Apps/plainpad_ynh"
 
 [planka]
 added_date = 1702558241 # 2023/12/14
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Trello" ]
@@ -3857,6 +4304,7 @@ url = "https://github.com/YunoHost-Apps/planka_ynh"
 
 [plateau]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 0
 state = "working"
@@ -3865,6 +4313,7 @@ url = "https://github.com/YunoHost-Apps/plateau_ynh"
 
 [pleroma]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 7
 potential_alternative_to = [ "X" ]
@@ -3874,6 +4323,7 @@ url = "https://github.com/YunoHost-Apps/pleroma_ynh"
 
 [plume]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "Medium" ]
@@ -3883,6 +4333,7 @@ url = "https://github.com/YunoHost-Apps/plume_ynh"
 
 [pluxml]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3891,6 +4342,7 @@ url = "https://github.com/YunoHost-Apps/pluxml_ynh"
 
 [pmwiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -3899,6 +4351,7 @@ url = "https://github.com/YunoHost-Apps/pmwiki_ynh"
 
 [prestashop]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -3907,6 +4360,7 @@ url = "https://github.com/YunoHost-Apps/prestashop_ynh"
 
 [pretalx]
 added_date = 1745268525 # 2025/04/21
+branch = "master"
 category = "communication"
 level = 0
 potential_alternative_to = [ "Zoho Backstage" ]
@@ -3917,6 +4371,7 @@ url = "https://github.com/YunoHost-Apps/pretalx_ynh"
 [prettynoemiecms]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -3927,6 +4382,7 @@ url = "https://github.com/YunoHost-Apps/prettynoemiecms_ynh"
 
 [privatebin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "Pastebin", "ZeroBin" ]
@@ -3936,6 +4392,7 @@ url = "https://github.com/YunoHost-Apps/privatebin_ynh"
 
 [privtracker]
 added_date = 1737920236 # 2025/01/26
+branch = "master"
 category = "multimedia"
 level = 7
 potential_alternative_to = [ "µTorrent" ]
@@ -3945,6 +4402,7 @@ url = "https://github.com/YunoHost-Apps/privtracker_ynh"
 
 [processwire]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 0
 potential_alternative_to = [ "Blogger", "Blogspot", "Wix" ]
@@ -3964,6 +4422,7 @@ url = "https://github.com/YunoHost-Apps/projectsend_ynh"
 
 [prometheus]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -3972,6 +4431,7 @@ url = "https://github.com/YunoHost-Apps/prometheus_ynh"
 
 [prose]
 added_date = 1739112393 # 2025/02/09
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -3981,6 +4441,7 @@ url = "https://github.com/YunoHost-Apps/prose_ynh"
 
 [prosody]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 state = "working"
@@ -3989,6 +4450,7 @@ url = "https://github.com/YunoHost-Apps/prosody_ynh"
 
 [prowlarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -3996,6 +4458,7 @@ url = "https://github.com/YunoHost-Apps/prowlarr_ynh"
 
 [proxitok]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 0
 potential_alternative_to = [ "TikTok" ]
@@ -4004,6 +4467,7 @@ url = "https://github.com/YunoHost-Apps/proxitok_ynh"
 
 [psitransfer]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "WeTransfer" ]
@@ -4013,6 +4477,7 @@ url = "https://github.com/YunoHost-Apps/psitransfer_ynh"
 
 [pterodactyl]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 7
 state = "working"
@@ -4021,6 +4486,7 @@ url = "https://github.com/YunoHost-Apps/pterodactyl_ynh"
 
 [pufferpanel]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -4028,6 +4494,7 @@ url = "https://github.com/YunoHost-Apps/pufferpanel_ynh"
 
 [pydio]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Google Drive", "Microsoft OneDrive" ]
@@ -4037,6 +4504,7 @@ url = "https://github.com/YunoHost-Apps/pydio_ynh"
 
 [pyinventory]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -4045,6 +4513,7 @@ url = "https://github.com/YunoHost-Apps/pyinventory_ynh"
 
 [pyload]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -4052,6 +4521,7 @@ url = "https://github.com/YunoHost-Apps/pyload_ynh"
 
 [pytition]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Avaaz", "Change" ]
@@ -4061,6 +4531,7 @@ url = "https://github.com/YunoHost-Apps/pytition_ynh"
 
 [qbittorrent]
 added_date = 1678129147 # 2023/03/06
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "µTorrent" ]
@@ -4070,6 +4541,7 @@ url = "https://github.com/YunoHost-Apps/qbittorrent_ynh"
 
 [qr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4077,6 +4549,7 @@ url = "https://code.antopie.org/miraty/qr_ynh"
 
 [question2answer]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 potential_alternative_to = [ "Stack Exchange", "Stack Overflow" ]
@@ -4085,6 +4558,7 @@ url = "https://github.com/YunoHost-Apps/question2answer_ynh"
 
 [quizzes]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 6
 state = "working"
@@ -4093,6 +4567,7 @@ url = "https://github.com/YunoHost-Apps/quizzes_ynh"
 
 [radarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -4100,6 +4575,7 @@ url = "https://github.com/YunoHost-Apps/radarr_ynh"
 
 [radicale]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 0
 state = "notworking"
@@ -4108,6 +4584,7 @@ url = "https://github.com/YunoHost-Apps/radicale_ynh"
 
 [rallly]
 added_date = 1708020558 # 2024/02/15
+branch = "master"
 category = "productivity_and_management"
 level = 7
 potential_alternative_to = [ "Doodle" ]
@@ -4117,6 +4594,7 @@ url = "https://github.com/YunoHost-Apps/rallly_ynh"
 
 [rclone]
 added_date = 1718745783 # 2024/06/18
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -4125,6 +4603,7 @@ url = "https://github.com/YunoHost-Apps/rclone_ynh"
 
 [readarr]
 added_date = 1696451897 # 2023/10/04
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4133,6 +4612,7 @@ url = "https://github.com/YunoHost-Apps/readarr_ynh"
 
 [readeck]
 added_date = 1707572608 # 2024/02/10
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Pocket", "Shaarli", "Wallabag" ]
@@ -4149,6 +4629,7 @@ url = "https://github.com/YunoHost-Apps/readflow_ynh"
 
 [redirect]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4157,6 +4638,7 @@ url = "https://github.com/YunoHost-Apps/redirect_ynh"
 
 [redlib]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 7
 potential_alternative_to = [ "Hacker News", "Lobste.rs", "Reddit" ]
@@ -4165,6 +4647,7 @@ url = "https://github.com/YunoHost-Apps/redlib_ynh"
 
 [redmine]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -4174,6 +4657,7 @@ url = "https://github.com/YunoHost-Apps/redmine_ynh"
 [reiverr]
 added_date = 1698585254 # 2023/10/29
 antifeatures = [ "alpha-software" ]
+branch = "master"
 category = "multimedia"
 level = 7
 potential_alternative_to = [ "Jellyfin-vue", "Jellyseerr", "Overseerr" ]
@@ -4183,6 +4667,7 @@ url = "https://github.com/YunoHost-Apps/reiverr_ynh"
 
 [restic]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4191,6 +4676,7 @@ url = "https://github.com/YunoHost-Apps/restic_ynh"
 
 [retroarch]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 6
 state = "working"
@@ -4198,6 +4684,7 @@ url = "https://github.com/YunoHost-Apps/retroarch_ynh"
 
 [revealjs]
 added_date = 1742237211 # 2025/03/17
+branch = "master"
 category = "office"
 level = 7
 potential_alternative_to = [ "Google Slides", "Office 365", "Prezi", "SoZi" ]
@@ -4207,6 +4694,7 @@ url = "https://github.com/YunoHost-Apps/revealjs_ynh"
 
 [reverseproxy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4216,6 +4704,7 @@ url = "https://github.com/YunoHost-Apps/reverseproxy_ynh"
 [rocketchat]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "not-totally-free-upstream" ]
+branch = "master"
 category = "communication"
 level = 7
 potential_alternative_to = [ "Slack" ]
@@ -4225,6 +4714,7 @@ url = "https://github.com/YunoHost-Apps/rocketchat_ynh"
 
 [roundcube]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
@@ -4234,6 +4724,7 @@ url = "https://github.com/YunoHost-Apps/roundcube_ynh"
 
 [rspamd]
 added_date = 1730230504 # 2024/10/29
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -4242,6 +4733,7 @@ url = "https://github.com/YunoHost-Apps/rspamd_ynh"
 
 [rspamdui]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -4250,6 +4742,7 @@ url = "https://github.com/YunoHost-Apps/rspamdui_ynh"
 
 [rss-bridge]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4257,6 +4750,7 @@ url = "https://github.com/YunoHost-Apps/rss-bridge_ynh"
 
 [rsshub]
 added_date = 1696613491 # 2023/10/06
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4264,6 +4758,7 @@ url = "https://github.com/YunoHost-Apps/rsshub_ynh"
 
 [rustdesk-server]
 added_date = 1698869593 # 2023/11/01
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "AnyDesk", "TeamViewer" ]
@@ -4272,6 +4767,7 @@ url = "https://github.com/YunoHost-Apps/rustdesk-server_ynh"
 
 [samba]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -4279,6 +4775,7 @@ url = "https://github.com/YunoHost-Apps/samba_ynh"
 
 [satdress]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -4286,6 +4783,7 @@ url = "https://github.com/YunoHost-Apps/satdress_ynh"
 
 [scovie]
 added_date = 1685183203 # 2023/05/27
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -4294,6 +4792,7 @@ url = "https://github.com/YunoHost-Apps/scovie_ynh"
 
 [scratch]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -4302,6 +4801,7 @@ url = "https://github.com/YunoHost-Apps/scratch_ynh"
 
 [screego]
 added_date = 1725285852 # 2024/09/02
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -4311,6 +4811,7 @@ url = "https://github.com/YunoHost-Apps/screego_ynh"
 [scrumblr]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4319,6 +4820,7 @@ url = "https://github.com/YunoHost-Apps/scrumblr_ynh"
 
 [scrutiny]
 added_date = 1678351205 # 2023/03/09
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4327,6 +4829,7 @@ url = "https://github.com/YunoHost-Apps/scrutiny_ynh"
 
 [seafile]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Dropbox", "Google Drive", "Mega", "Microsoft OneDrive", "Resilio Sync", "Time Machine" ]
@@ -4336,6 +4839,7 @@ url = "https://github.com/YunoHost-Apps/seafile_ynh"
 
 [searxng]
 added_date = 1678310393 # 2023/03/08
+branch = "master"
 category = "small_utilities"
 level = 6
 potential_alternative_to = [ "Bing", "DuckDuckGo", "Google", "SearX", "Yahoo" ]
@@ -4344,6 +4848,7 @@ url = "https://github.com/YunoHost-Apps/searxng_ynh"
 
 [selfoss]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4352,6 +4857,7 @@ url = "https://github.com/YunoHost-Apps/selfoss_ynh"
 
 [send]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "WeTransfer" ]
@@ -4361,6 +4867,7 @@ url = "https://github.com/YunoHost-Apps/send_ynh"
 
 [shaarli]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Delicious", "Diigo" ]
@@ -4370,6 +4877,7 @@ url = "https://github.com/YunoHost-Apps/shaarli_ynh"
 
 [sharkey]
 added_date = 1707378045 # 2024/02/08
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Calckey", "Firefish", "Mastodon", "Misskey", "Pleroma", "Threads", "X" ]
@@ -4380,6 +4888,7 @@ url = "https://github.com/YunoHost-Apps/sharkey_ynh"
 [shellinabox]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "system_tools"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -4388,6 +4897,7 @@ url = "https://github.com/YunoHost-Apps/shellinabox_ynh"
 
 [shields]
 added_date = 1731863011 # 2024/11/17
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -4395,6 +4905,7 @@ url = "https://github.com/YunoHost-Apps/shields_ynh"
 
 [shiori]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4402,6 +4913,7 @@ url = "https://github.com/YunoHost-Apps/shiori_ynh"
 
 [shlink]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 0
 potential_alternative_to = [ "bitly" ]
@@ -4412,6 +4924,7 @@ url = "https://github.com/YunoHost-Apps/shlink_ynh"
 [shuri]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4422,6 +4935,7 @@ url = "https://github.com/YunoHost-Apps/shuri_ynh"
 
 [signaturepdf]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4429,6 +4943,7 @@ url = "https://github.com/YunoHost-Apps/signaturepdf_ynh"
 
 [silverbullet]
 added_date = 1710170758 # 2024/03/11
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Joplin", "Logseq", "Microsoft OneNote", "Obsidian" ]
@@ -4439,6 +4954,7 @@ url = "https://github.com/YunoHost-Apps/silverbullet_ynh"
 [simple-hash-generator]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4447,6 +4963,7 @@ url = "https://github.com/YunoHost-Apps/simple-hash-generator_ynh"
 
 [simplex]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -4456,6 +4973,7 @@ url = "https://github.com/YunoHost-Apps/simplex_ynh"
 [simplytranslate]
 added_date = 1685875056 # 2023/06/04
 antifeatures = [ "deprecated-software", "non-free-network" ]
+branch = "master"
 category = "small_utilities"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4465,6 +4983,7 @@ url = "https://github.com/YunoHost-Apps/simplytranslate_ynh"
 [sitemagiccms]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "publishing"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -4475,6 +4994,7 @@ url = "https://github.com/YunoHost-Apps/sitemagiccms_ynh"
 [slingcode]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "dev"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4484,6 +5004,7 @@ url = "https://github.com/YunoHost-Apps/slingcode_ynh"
 
 [snappymail]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "GMail", "Hotmail", "Microsoft Outlook", "Yahoo! Mail" ]
@@ -4493,6 +5014,7 @@ url = "https://github.com/YunoHost-Apps/snappymail_ynh"
 
 [snipeit]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -4502,6 +5024,7 @@ url = "https://github.com/YunoHost-Apps/snipeit_ynh"
 [snserver]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-assets", "package-not-maintained" ]
+branch = "master"
 category = "office"
 level = 7
 state = "working"
@@ -4511,6 +5034,7 @@ url = "https://github.com/YunoHost-Apps/snserver_ynh"
 [snweb]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "office"
 level = 7
 state = "working"
@@ -4519,6 +5043,7 @@ url = "https://github.com/YunoHost-Apps/snweb_ynh"
 
 [soapbox]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 state = "working"
@@ -4527,6 +5052,7 @@ url = "https://github.com/YunoHost-Apps/soapbox_ynh"
 
 [sogo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -4535,6 +5061,7 @@ url = "https://github.com/YunoHost-Apps/sogo_ynh"
 
 [sonarr]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 state = "working"
@@ -4542,6 +5069,7 @@ url = "https://github.com/YunoHost-Apps/sonarr_ynh"
 
 [spacedeck]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -4549,6 +5077,7 @@ url = "https://github.com/YunoHost-Apps/spacedeck_ynh"
 
 [spftoolbox]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4556,6 +5085,7 @@ url = "https://github.com/YunoHost-Apps/spftoolbox_ynh"
 
 [spip]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Blogger", "Coldfusion", "Wix" ]
@@ -4565,6 +5095,7 @@ url = "https://github.com/YunoHost-Apps/spip_ynh"
 
 [squid3]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4573,6 +5104,7 @@ url = "https://github.com/YunoHost-Apps/squid3_ynh"
 
 [ssbroom]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -4581,6 +5113,7 @@ url = "https://github.com/YunoHost-Apps/ssbroom_ynh"
 [ssh_chroot_dir]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "system_tools"
 deprecated_date = 1717071136 # 2024/05/30
 level = 6
@@ -4589,6 +5122,7 @@ url = "https://github.com/YunoHost-Apps/ssh_chroot_dir_ynh"
 
 [sshwifty]
 added_date = 1729325184 # 2024/10/19
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -4596,6 +5130,7 @@ url = "https://github.com/YunoHost-Apps/sshwifty_ynh"
 
 [statpingng]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4604,6 +5139,7 @@ url = "https://github.com/YunoHost-Apps/statpingng_ynh"
 
 [stirling-pdf]
 added_date = 1727854840 # 2024/10/02
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -4611,6 +5147,7 @@ url = "https://github.com/YunoHost-Apps/stirling-pdf_ynh"
 
 [streama]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 state = "working"
@@ -4619,6 +5156,7 @@ url = "https://github.com/YunoHost-Apps/streama_ynh"
 
 [streams]
 added_date = 1691216343 # 2023/08/05
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Facebook", "Threads", "Tumblr", "X" ]
@@ -4628,6 +5166,7 @@ url = "https://github.com/YunoHost-Apps/streams_ynh"
 
 [stremio]
 added_date = 1730914119 # 2024/11/06
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -4637,6 +5176,7 @@ url = "https://github.com/YunoHost-Apps/stremio_ynh"
 [strut]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "office"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4647,6 +5187,7 @@ url = "https://github.com/YunoHost-Apps/strut_ynh"
 
 [superset]
 added_date = 1706951650 # 2024/02/03
+branch = "master"
 category = "wat"
 level = 6
 state = "working"
@@ -4654,6 +5195,7 @@ url = "https://github.com/YunoHost-Apps/superset_ynh"
 
 [sutom]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -4661,6 +5203,7 @@ url = "https://github.com/YunoHost-Apps/sutom_ynh"
 
 [svgedit]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -4669,6 +5212,7 @@ url = "https://github.com/YunoHost-Apps/svgedit_ynh"
 
 [swingmusic]
 added_date = 1741447190 # 2025/03/08
+branch = "master"
 category = "multimedia"
 level = 7
 state = "working"
@@ -4676,6 +5220,7 @@ url = "https://github.com/YunoHost-Apps/swingmusic_ynh"
 
 [synapse]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 potential_alternative_to = [ "Discord", "Facebook Messenger", "Signal", "Skype", "Telegram", "Whatsapp" ]
@@ -4685,6 +5230,7 @@ url = "https://github.com/YunoHost-Apps/synapse_ynh"
 
 [synapse-admin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -4693,6 +5239,7 @@ url = "https://github.com/YunoHost-Apps/synapse-admin_ynh"
 
 [syncserver-rs]
 added_date = 1697360862 # 2023/10/15
+branch = "master"
 category = "synchronization"
 level = 8
 state = "working"
@@ -4700,6 +5247,7 @@ url = "https://github.com/YunoHost-Apps/syncserver-rs_ynh"
 
 [syncthing]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "Dropbox", "Google Drive", "Microsoft OneDrive" ]
@@ -4709,6 +5257,7 @@ url = "https://github.com/YunoHost-Apps/syncthing_ynh"
 
 [tableaunoir]
 added_date = 1725978910 # 2024/09/10
+branch = "master"
 category = "office"
 level = 0
 state = "working"
@@ -4717,6 +5266,7 @@ url = "https://github.com/YunoHost-Apps/tableaunoir_ynh"
 
 [tandoor]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4725,6 +5275,7 @@ url = "https://github.com/YunoHost-Apps/tandoor_ynh"
 [taskboard]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software", "package-not-maintained" ]
+branch = "master"
 category = "productivity_and_management"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4735,6 +5286,7 @@ url = "https://github.com/YunoHost-Apps/taskboard_ynh"
 
 [teampass]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "1Password", "Dashlane", "Enpass", "LastPass" ]
@@ -4744,6 +5296,7 @@ url = "https://github.com/YunoHost-Apps/teampass_ynh"
 
 [technitium-dns]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4753,6 +5306,7 @@ url = "https://github.com/YunoHost-Apps/technitium-dns_ynh"
 [teddit]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "social_media"
 deprecated_date = 1708218190 # 2024/02/18
 level = 6
@@ -4762,6 +5316,7 @@ url = "https://github.com/YunoHost-Apps/teddit_ynh"
 
 [terraforming-mars]
 added_date = 1698757901 # 2023/10/31
+branch = "master"
 category = "games"
 level = 8
 state = "working"
@@ -4769,6 +5324,7 @@ url = "https://github.com/YunoHost-Apps/terraforming-mars_ynh"
 
 [thelounge]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 6
 state = "working"
@@ -4777,6 +5333,7 @@ url = "https://github.com/YunoHost-Apps/thelounge_ynh"
 
 [tiddlywiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Evernote", "GitBook" ]
@@ -4786,6 +5343,7 @@ url = "https://github.com/YunoHost-Apps/tiddlywiki_ynh"
 
 [tiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -4794,6 +5352,7 @@ url = "https://github.com/YunoHost-Apps/tiki_ynh"
 
 [timemachine]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4802,6 +5361,7 @@ url = "https://github.com/YunoHost-Apps/timemachine_ynh"
 
 [timeoff]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -4810,6 +5370,7 @@ url = "https://github.com/YunoHost-Apps/timeoff_ynh"
 
 [tinyfilemanager]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4817,6 +5378,7 @@ url = "https://github.com/YunoHost-Apps/tinyfilemanager_ynh"
 
 [tldraw]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Lucidchart" ]
@@ -4835,6 +5397,7 @@ url = "https://github.com/YunoHost-Apps/tooljet_ynh"
 
 [torrelay]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4843,6 +5406,7 @@ url = "https://github.com/YunoHost-Apps/torrelay_ynh"
 
 [traccar]
 added_date = 1700418281 # 2023/11/19
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4850,6 +5414,7 @@ url = "https://github.com/YunoHost-Apps/traccar_ynh"
 
 [tracim]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 6
 potential_alternative_to = [ "Dropbox", "Google Drive", "Slack", "Trello" ]
@@ -4858,6 +5423,7 @@ url = "https://github.com/YunoHost-Apps/tracim_ynh"
 
 [traggo]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 state = "working"
@@ -4866,6 +5432,7 @@ url = "https://github.com/YunoHost-Apps/traggo_ynh"
 
 [transfersh]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 state = "working"
@@ -4874,6 +5441,7 @@ url = "https://github.com/YunoHost-Apps/transfersh_ynh"
 
 [transmission]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "µTorrent" ]
@@ -4883,6 +5451,7 @@ url = "https://github.com/YunoHost-Apps/transmission_ynh"
 
 [trilium]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 potential_alternative_to = [ "Evernote" ]
@@ -4892,6 +5461,7 @@ url = "https://github.com/YunoHost-Apps/trilium_ynh"
 
 [trustyhash]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -4899,6 +5469,7 @@ url = "https://github.com/YunoHost-Apps/trustyhash_ynh"
 
 [ttrss]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -4907,6 +5478,7 @@ url = "https://github.com/YunoHost-Apps/ttrss_ynh"
 
 [tube]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 8
 potential_alternative_to = [ "Dailymotion", "Vimeo", "YouTube" ]
@@ -4917,6 +5489,7 @@ url = "https://github.com/YunoHost-Apps/tube_ynh"
 [turtl]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "package-not-maintained" ]
+branch = "master"
 category = "publishing"
 level = 7
 potential_alternative_to = [ "Evernote", "Google Keep", "Notion" ]
@@ -4926,6 +5499,7 @@ url = "https://github.com/YunoHost-Apps/turtl_ynh"
 
 [tvheadend]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 0
 state = "working"
@@ -4934,6 +5508,7 @@ url = "https://github.com/YunoHost-Apps/tvheadend_ynh"
 [tyto]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "productivity_and_management"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -4943,6 +5518,7 @@ url = "https://github.com/YunoHost-Apps/tyto_ynh"
 
 [ulogger]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 1
 state = "working"
@@ -4950,6 +5526,7 @@ url = "https://github.com/YunoHost-Apps/ulogger_ynh"
 
 [umami]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 potential_alternative_to = [ "Google Analytics" ]
@@ -4959,6 +5536,7 @@ url = "https://github.com/YunoHost-Apps/umami_ynh"
 
 [ums]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "multimedia"
 level = 6
 state = "working"
@@ -4966,6 +5544,7 @@ url = "https://github.com/YunoHost-Apps/ums_ynh"
 
 [unattended_upgrades]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4973,6 +5552,7 @@ url = "https://github.com/YunoHost-Apps/unattended_upgrades_ynh"
 
 [uptime-kuma]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -4981,6 +5561,7 @@ url = "https://github.com/YunoHost-Apps/uptime-kuma_ynh"
 
 [vaultwarden]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "1Password", "Bitwarden", "Dashlane", "Enpass", "LastPass" ]
@@ -4990,6 +5571,7 @@ url = "https://github.com/YunoHost-Apps/vaultwarden_ynh"
 
 [veloren]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "games"
 level = 0
 potential_alternative_to = [ "Minecraft" ]
@@ -4998,6 +5580,7 @@ url = "https://github.com/YunoHost-Apps/veloren_ynh"
 
 [vert]
 added_date = 1744530993 # 2025/04/13
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -5005,6 +5588,7 @@ url = "https://github.com/YunoHost-Apps/vert_ynh"
 
 [vikunja]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Microsoft To-Do", "Todoist", "Wunderlist" ]
@@ -5014,6 +5598,7 @@ url = "https://github.com/YunoHost-Apps/vikunja_ynh"
 
 [vore]
 added_date = 1690540859 # 2023/07/28
+branch = "master"
 category = "reading"
 level = 6
 state = "working"
@@ -5022,6 +5607,7 @@ url = "https://github.com/YunoHost-Apps/vore_ynh"
 
 [vpnclient]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -5039,6 +5625,7 @@ url = "https://github.com/YunoHost-Apps/vvveb_ynh"
 
 [wallabag2]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "reading"
 level = 8
 potential_alternative_to = [ "Pocket", "Shaarli" ]
@@ -5047,6 +5634,7 @@ url = "https://github.com/YunoHost-Apps/wallabag2_ynh"
 
 [wallos]
 added_date = 1730380821 # 2024/10/31
+branch = "master"
 category = "productivity_and_management"
 level = 7
 state = "working"
@@ -5055,6 +5643,7 @@ url = "https://github.com/YunoHost-Apps/wallos_ynh"
 
 [wanderer]
 added_date = 1730020711 # 2024/10/27
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "Komoot" ]
@@ -5063,6 +5652,7 @@ url = "https://github.com/YunoHost-Apps/wanderer_ynh"
 
 [watchdog]
 added_date = 1706943068 # 2024/02/03
+branch = "master"
 category = "system_tools"
 level = 8
 potential_alternative_to = [ "SwitchingItOffAndOnAgain" ]
@@ -5072,6 +5662,7 @@ url = "https://github.com/YunoHost-Apps/watchdog_ynh"
 
 [watchyourlan]
 added_date = 1729327985 # 2024/10/19
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -5079,6 +5670,7 @@ url = "https://github.com/YunoHost-Apps/watchyourlan_ynh"
 
 [webhook]
 added_date = 1742713121 # 2025/03/23
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -5086,6 +5678,7 @@ url = "https://github.com/YunoHost-Apps/webhook_ynh"
 
 [weblate]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 8
 potential_alternative_to = [ "Locize", "Transifex" ]
@@ -5094,6 +5687,7 @@ url = "https://github.com/YunoHost-Apps/weblate_ynh"
 
 [webmin]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -5101,6 +5695,7 @@ url = "https://github.com/YunoHost-Apps/webmin_ynh"
 
 [webtrees]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "wat"
 level = 8
 state = "working"
@@ -5108,6 +5703,7 @@ url = "https://github.com/YunoHost-Apps/webtrees_ynh"
 
 [wekan]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "productivity_and_management"
 level = 8
 potential_alternative_to = [ "Trello" ]
@@ -5118,6 +5714,7 @@ url = "https://github.com/YunoHost-Apps/wekan_ynh"
 [wemawema]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "deprecated-software" ]
+branch = "master"
 category = "wat"
 deprecated_date = 1717071136 # 2024/05/30
 level = 7
@@ -5126,6 +5723,7 @@ url = "https://github.com/YunoHost-Apps/wemawema_ynh"
 
 [wetty]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -5133,6 +5731,7 @@ url = "https://github.com/YunoHost-Apps/wetty_ynh"
 
 [whitebophir]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "office"
 level = 8
 state = "working"
@@ -5141,6 +5740,7 @@ url = "https://github.com/YunoHost-Apps/whitebophir_ynh"
 
 [whoogle]
 added_date = 1729357550 # 2024/10/19
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "Bing", "DuckDuckGo", "Google", "SearX", "Yahoo" ]
@@ -5149,6 +5749,7 @@ url = "https://github.com/YunoHost-Apps/whoogle_ynh"
 
 [wikijs]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "GitBook", "Notion" ]
@@ -5158,6 +5759,7 @@ url = "https://github.com/YunoHost-Apps/wikijs_ynh"
 
 [wireguard]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 0
 state = "working"
@@ -5166,6 +5768,7 @@ url = "https://github.com/YunoHost-Apps/wireguard_ynh"
 
 [wireguard_client]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 6
 state = "working"
@@ -5174,6 +5777,7 @@ url = "https://github.com/YunoHost-Apps/wireguard_client_ynh"
 
 [wondercms]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -5182,6 +5786,7 @@ url = "https://github.com/YunoHost-Apps/wondercms_ynh"
 
 [woodpecker]
 added_date = 1696247338 # 2023/10/02
+branch = "master"
 category = "dev"
 level = 8
 state = "working"
@@ -5191,6 +5796,7 @@ url = "https://github.com/YunoHost-Apps/woodpecker_ynh"
 [wordpress]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-addons", "paid-content" ]
+branch = "master"
 category = "publishing"
 level = 8
 potential_alternative_to = [ "Blogger", "Blogspot", "Wix" ]
@@ -5200,6 +5806,7 @@ url = "https://github.com/YunoHost-Apps/wordpress_ynh"
 
 [workout-tracker]
 added_date = 1712861274 # 2024/04/11
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "Strava" ]
@@ -5208,6 +5815,7 @@ url = "https://github.com/YunoHost-Apps/workout-tracker_ynh"
 
 [writefreely]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "social_media"
 level = 8
 potential_alternative_to = [ "Blogger", "Medium" ]
@@ -5217,6 +5825,7 @@ url = "https://github.com/YunoHost-Apps/writefreely_ynh"
 
 [x-prober]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -5225,6 +5834,7 @@ url = "https://github.com/YunoHost-Apps/x-prober_ynh"
 
 [xbackbone]
 added_date = 1692627384 # 2023/08/21
+branch = "master"
 category = "synchronization"
 level = 7
 potential_alternative_to = [ "WeTransfer" ]
@@ -5234,6 +5844,7 @@ url = "https://github.com/YunoHost-Apps/xbackbone_ynh"
 
 [xwiki]
 added_date = 1702980278 # 2023/12/19
+branch = "master"
 category = "publishing"
 level = 7
 potential_alternative_to = [ "GitBook", "Notion" ]
@@ -5243,6 +5854,7 @@ url = "https://github.com/YunoHost-Apps/xwiki_ynh"
 
 [yacy]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
@@ -5250,6 +5862,7 @@ url = "https://github.com/YunoHost-Apps/yacy_ynh"
 
 [yarr]
 added_date = 1715771420 # 2024/05/15
+branch = "master"
 category = "reading"
 level = 8
 state = "working"
@@ -5258,6 +5871,7 @@ url = "https://github.com/YunoHost-Apps/yarr_ynh"
 
 [yeetfile]
 added_date = 1744746650 # 2025/04/15
+branch = "master"
 category = "small_utilities"
 level = 6
 potential_alternative_to = [ "Pastebin", "ZeroBin" ]
@@ -5267,6 +5881,7 @@ url = "https://github.com/YunoHost-Apps/yeetfile_ynh"
 
 [yellow]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 8
 state = "working"
@@ -5275,6 +5890,7 @@ url = "https://github.com/YunoHost-Apps/yellow_ynh"
 
 [yeswiki]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -5283,6 +5899,7 @@ url = "https://github.com/YunoHost-Apps/yeswiki_ynh"
 
 [yourls]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "small_utilities"
 level = 8
 potential_alternative_to = [ "bitly" ]
@@ -5302,6 +5919,7 @@ url = "https://github.com/YunoHost-Apps/yuno-archive_ynh"
 
 [yunorunner]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "dev"
 level = 0
 state = "notworking"
@@ -5309,6 +5927,7 @@ url = "https://github.com/YunoHost-Apps/yunorunner_ynh"
 
 [z-push]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "synchronization"
 level = 0
 state = "working"
@@ -5317,6 +5936,7 @@ url = "https://github.com/YunoHost-Apps/z-push_ynh"
 
 [zabbix]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "system_tools"
 level = 7
 state = "working"
@@ -5326,6 +5946,7 @@ url = "https://github.com/YunoHost-Apps/zabbix_ynh"
 [zerobin]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "replaced-by-another-app" ]
+branch = "master"
 category = "small_utilities"
 level = 7
 potential_alternative_to = [ "Pastebin" ]
@@ -5336,6 +5957,7 @@ url = "https://github.com/YunoHost-Apps/zerobin_ynh"
 [zerotier]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-network", "not-totally-free-upstream" ]
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -5345,6 +5967,7 @@ url = "https://github.com/YunoHost-Apps/zerotier_ynh"
 [zeroui]
 added_date = 1693093567 # 2023/08/26
 antifeatures = [ "non-free-dependencies" ]
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -5353,6 +5976,7 @@ url = "https://github.com/YunoHost-Apps/zeroui_ynh"
 
 [zipline]
 added_date = 1696368077 # 2023/10/03
+branch = "master"
 category = "synchronization"
 level = 8
 potential_alternative_to = [ "WeTransfer" ]
@@ -5362,6 +5986,7 @@ url = "https://github.com/YunoHost-Apps/zipline_ynh"
 
 [zola]
 added_date = 1718733357 # 2024/06/18
+branch = "master"
 category = "publishing"
 level = 6
 state = "working"
@@ -5370,6 +5995,7 @@ url = "https://github.com/YunoHost-Apps/zola_ynh"
 
 [zoraxy]
 added_date = 1725542118 # 2024/09/05
+branch = "master"
 category = "small_utilities"
 level = 7
 state = "working"
@@ -5379,6 +6005,7 @@ url = "https://github.com/YunoHost-Apps/zoraxy_ynh"
 [ztncui]
 added_date = 1674232499 # 2023/01/20
 antifeatures = [ "non-free-dependencies" ]
+branch = "master"
 category = "system_tools"
 level = 8
 state = "working"
@@ -5387,6 +6014,7 @@ url = "https://github.com/YunoHost-Apps/ztncui_ynh"
 
 [zusam]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "communication"
 level = 8
 state = "working"
@@ -5395,6 +6023,7 @@ url = "https://github.com/YunoHost-Apps/zusam_ynh"
 
 [zwave-js-ui]
 added_date = 1674232499 # 2023/01/20
+branch = "master"
 category = "iot"
 level = 8
 state = "working"
@@ -5407,3 +6036,4 @@ level = 8
 state = "working"
 subtags = [ "website" ]
 url = "https://github.com/YunoHost-Apps/zwiicms_ynh"
+branch = "master"


### PR DESCRIPTION
## Context

We often get this type of error from the list builder in the chat:
```
[Apps tools error] [List builder] Error while updating lasuite-docs: No cache yet for lasuite-docs
```

This error currently is fixed by adding `branch = "main"` in the section dedicated to the guilty app.

## Proposed solution

I suggest to consider the contrary: the default branch should now be `main`:
 - the `example_ynh` boilerplate default branch now is `main`;
 - New repositories in Github are initialized with a `main` branch;

This PR changes the app catalog to specify explicitly the branch.

Here is the script I used for that:
```py
#!/usr/bin/env python3

import tomlkit

with open("apps.toml", "r", encoding = "utf-8") as f:
    apps = tomlkit.load(f)

for key, info in apps.items():
    if not info.get("branch", None):
        info["branch"] = "master"

with open("apps.toml", "w", encoding = "utf-8") as f:
    tomlkit.dump(apps, f)

```

Unfortunately, I am not a Pythonist, I could not manage to sort the properties through this script, I used my editor for that 😟.

## NB

This PR is meant to be merged with this other one: https://github.com/YunoHost/apps_tools/pull/43