### PR TITLE
add paid-content antifeature to rallly

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -4612,6 +4612,7 @@ url = "https://github.com/YunoHost-Apps/radicale_ynh"
 
 [rallly]
 added_date = 1708020558 # 2024/02/15
+antifeatures = [ "paid-content" ]
 branch = "master"
 category = "productivity_and_management"
 level = 7


### PR DESCRIPTION
While refactoring rallly, I’ve found that it’s free only for one person (https://support.rallly.co/self-hosting/licensing)