### PR TITLE
Add deprecation warning to Dendrite

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -940,7 +940,7 @@ url = "https://github.com/YunoHost-Apps/deluge_ynh"
 
 [dendrite]
 added_date = 1674232499 # 2023/01/20
-antifeatures = [ "alpha-software" ]
+antifeatures = [ "deprecated-software" ]
 branch = "master"
 category = "communication"
 level = 7


### PR DESCRIPTION
To be merged after https://github.com/element-hq/dendrite/pull/3627, which clarifies that Dendrite is in maintenance mode.

- [x] add a custom antifeature in dendrite_ynh to clarify that only security releases will be done in the future, and no new features will be added.