### PR TITLE
Add tuwunel to the catalog

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -5554,6 +5554,13 @@ state = "working"
 subtags = [ "wiki" ]
 url = "https://github.com/YunoHost-Apps/turtl_ynh"
 
+[tuwunel]
+branch = "main"
+category = "communication"
+potential_alternative_to = [ "Synapse", "Dendrite", "Conduit" ]
+state = "working"
+url = "https://github.com/YunoHost-Apps/tuwunel_ynh"
+
 [tvheadend]
 added_date = 1674232499 # 2023/01/20
 branch = "master"

--- a/apps.toml
+++ b/apps.toml
@@ -5557,7 +5557,7 @@ url = "https://github.com/YunoHost-Apps/turtl_ynh"
 [tuwunel]
 branch = "main"
 category = "communication"
-potential_alternative_to = [ "Synapse", "Dendrite", "Conduit" ]
+potential_alternative_to = [ "Conduit", "Dendrite", "Synapse" ]
 state = "working"
 url = "https://github.com/YunoHost-Apps/tuwunel_ynh"
 

--- a/wishlist.toml
+++ b/wishlist.toml
@@ -2597,13 +2597,6 @@ website = "https://tuta.com/"
 draft = "https://github.com/YunoHost-Apps/tutao_ynh"
 added_date = 1695656621  # 2023/09/25
 
-[tuwunel]
-name = "Tuwunel"
-description = "Matrix server written in Rust, successor to conduwuit with stable governance"
-upstream = "https://github.com/matrix-construct/tuwunel"
-website = ""
-added_date = 1744830694  # 2025/04/16
-
 [twake-app]
 name = "Twake.app"
 description = "Collaboration platform to improve organizational productivity"


### PR DESCRIPTION
Waiting for https://ci-apps-dev.yunohost.org/ci/job/11962

Or actually not waiting as ci-apps-dev runs `stable` and Tuwunel requires `testing` (for now).

Perhaps this one should remain in limbo until `12.1` officially releases?