### PR TITLE
Fix `subtags` for `tube`

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -5034,7 +5034,7 @@ category = "multimedia"
 level = 8
 potential_alternative_to = [ "Dailymotion", "Vimeo", "YouTube" ]
 state = "working"
-subtags = [ "video" ]
+subtags = [ "videos" ]
 url = "https://github.com/YunoHost-Apps/tube_ynh"
 
 [turtl]


### PR DESCRIPTION
```
tube:
  - warning: unknown subtag multimedia / video
```

Other apps are using `videos` subtag.