### PR TITLE
Move DirectoryLister and Gossa into files sub category

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -930,6 +930,7 @@ branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
+subtags = [ "files" ]
 url = "https://github.com/YunoHost-Apps/directorylister_ynh"
 
 [discourse]
@@ -1804,6 +1805,7 @@ branch = "master"
 category = "small_utilities"
 level = 8
 state = "working"
+subtags = [ "files" ]
 url = "https://github.com/YunoHost-Apps/gossa_ynh"
 
 [gotify]


### PR DESCRIPTION
Move DirectoryLister and Gossa into files sub category.  While those apps are not exactly files managers, I think it is more obvious to find them in this category than in the _fourre-tout_ "others"