### PR TITLE
move Grocy to productivity and management category

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1868,9 +1868,10 @@ url = "https://github.com/YunoHost-Apps/grist_ynh"
 [grocy]
 added_date = 1674232499 # 2023/01/20
 branch = "master"
-category = "small_utilities"
+category = "productivity_and_management"
 level = 8
 state = "working"
+subtags = [ "business_and_ngos" ]
 url = "https://github.com/YunoHost-Apps/grocy_ynh"
 
 [grr]


### PR DESCRIPTION
I am not sure of that, but my rationale is that Grocy is lost in the small utilities category and that it will be easier to find it in management. Additionaly, I added the business_and_ngos sub category.