### PR TITLE
manifest schema: Add filter property and language version

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -307,6 +307,9 @@
                                 }
                             }
                         },
+                        "filter": {
+                            "type": "string"
+                        },
                         "visible": {
                             "oneOf": [
                                 {


### PR DESCRIPTION
Fixes https://github.com/YunoHost/issues/issues/2615

~~⚠️ Please note that I could not test that myself, due to difficulties for running `package_linter`, so check that it works for you before merging.~~

Before:
```
  Analyzing app ../apps/docs_ynh ...

 ⓘ manifest

    - Error validating manifest using schema: in key install > dex
       Additional properties are not allowed ('filter' was unexpected)
    - Error validating manifest using schema: in key install > s3
       Additional properties are not allowed ('filter' was unexpected)
    - Error validating manifest using schema: in key resources
       Additional properties are not allowed ('nodejs' was unexpected)
```

After:
```
 ⓘ manifest

    - Error validating manifest using schema: in key resources
       Additional properties are not allowed ('nodejs' was unexpected)
```