### PR TITLE
manifest schema: Add NodeJS/Ruby/Go/Composer resources

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -684,6 +684,17 @@
                             "pattern": "^([0-9]*\\.)*[0-9]*$"
                         }
                     }
+                },
+                "composer": {
+                    "type": "object",
+                    "required": ["version"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "version": {
+                            "type": "string",
+                            "pattern": "^([0-9]*\\.)*[0-9]*$"
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Context

NodeJS / Ruby / Go resources have recently been added to the manifest.

However, the package linter reports validation issues.

## Proposed solution

Update the jsonschema of the manifest

## How to test

You may tests against `lasuite-docs` (nodejs), `wanderer_ynh` (go) and on a branch of `redmine` (ruby):
```
$ cd /path/to/package_linter
$ git clone git@github.com:YunoHost-Apps/wanderer_ynh.git
$ git clone git@github.com:YunoHost-Apps/lasuite-docs_ynh.git
$ git clone git@github.com:yunohost-bot/redmine_ynh.git -b auto-nodejs-ruby-go-composer-resources
$ source venv/bin/activate
# Let's remove the cached manifest first and verify the issue reported above exist
$ rm .manifest.v2.schema.json
$ ./package_linter.py ./wanderer_ynh
$ ./package_linter.py ./lasuite-docs_ynh
$ ./package_linter.py ./redmine_ynh
# Let's try with the new manifest
$ curl https://raw.githubusercontent.com/fflorent/yunohost-apps/refs/heads/patch-4/schemas/manifest.v2.schema.json > .manifest.v2.schema.json
$ ./package_linter.py ./wanderer_ynh
$ ./package_linter.py ./lasuite-docs_ynh
$ ./package_linter.py ./redmine_ynh
```