### PR TITLE
Add ahwa

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -134,6 +134,13 @@ level = 8
 state = "working"
 url = "https://github.com/YunoHost-Apps/agorakit_ynh"
 
+[ahwa]
+added_date = 1776470400 # 2026/04/18
+branch = "main"
+category = "small_utilities"
+state = "inprogress"
+url = "https://github.com/remoun/ahwa_ynh"
+
 [airsonic]
 added_date = 1674232499 # 2023/01/20
 branch = "master"


### PR DESCRIPTION
- App URL: https://github.com/remoun/ahwa_ynh
- Upstream: https://github.com/remoun/ahwa

**Ahwa** is a privacy-first FOSS multi-persona deliberation tool. Set a table, invite a council of AI personas (Anthropic, OpenAI, OpenRouter, or local Ollama), and pose a dilemma. The council debates it across structured rounds; a synthesizer produces a recommendation that preserves real disagreement. AGPL-3.0, zero telemetry, fully self-hostable.

**State: `inprogress`** — package functionally complete and verified end-to-end on a live VPS, but I'd appreciate reviewer input on a `package_check` curl-test failure (see below) before flipping to `working`.

## Verification done

- ✅ Install / remove / upgrade / backup / restore scripts work on a live YunoHost 12.1.39 install (`make deploy` from the repo).
- ✅ End-to-end SSO check passes: SSOwat → nginx → Ahwa `Auth-User` header → app's `/api/me` returns the YNH user as `external_id`. Automated via [`tests/sso-e2e.sh`](https://github.com/remoun/ahwa_ynh/blob/main/tests/sso-e2e.sh) which runs from both the dev Mac and CI ([sso-e2e.yml](https://github.com/remoun/ahwa_ynh/blob/main/.github/workflows/sso-e2e.yml)).
- ✅ Tarball is pinned (not `git clone`) and ships a prebuilt `build/` so `bun run build` doesn't need to run inside the LXC ([resources.sources.main](https://github.com/remoun/ahwa_ynh/blob/main/manifest.toml)).

## `package_check` status — input requested

Latest run: install succeeds for `Test 2/7 Installation on the root` and `Test 3/7 Installation in a sub path`, but each fails at the post-install curl test with:

```
pycurl.error: (7, "Failed to connect to sub.domain.tld port 443 after 3061 ms: Couldn't connect to server")
```

Tests 4–7 cascade-skip (their setup depends on tests 2/3 finishing without FAIL).

Diagnostic so far: install logs show `Configuring nginx...` and `Starting Ahwa...` succeed; the app's systemd unit boots; the failure is the curl probe against the test container's `sub.domain.tld:443`. Looks like either the test container's self-signed cert didn't provision (so `listen 443 ssl` doesn't bind) or `sub.domain.tld` isn't resolving inside the container.

**Question for reviewers**: is this a known package_check / runner-environment issue, or is there something in our nginx config / install script that's preventing the test domain from binding 443? Our [nginx.conf](https://github.com/remoun/ahwa_ynh/blob/main/conf/nginx.conf) is a standard `location` block; YNH's standard server template wraps it.

Marking as **draft** so reviewers can flag concerns before promoting. Happy to transfer the package to YunoHost-Apps and rename if accepted.
