### PR TITLE
Add openwebui

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3775,6 +3775,14 @@ state = "working"
 subtags = [ "calendar" ]
 url = "https://github.com/YunoHost-Apps/open-web-calendar_ynh"
 
+[openwebui]
+added_date = 1776470400 # 2026/04/18
+branch = "main"
+category = "small_utilities"
+potential_alternative_to = [ "ChatGPT" ]
+state = "inprogress"
+url = "https://github.com/remoun/openwebui_ynh"
+
 [opencloud]
 added_date = 1740568746 # 2025/02/26
 branch = "master"


### PR DESCRIPTION
- App URL: https://github.com/remoun/openwebui_ynh
- Upstream: https://github.com/open-webui/open-webui

**Open WebUI** is a self-hosted, user-friendly web interface for LLM chat, supporting Ollama and OpenAI-compatible APIs. MIT-licensed, very active upstream.

State: \`inprogress\` — package is functional locally; pending a clean package_check pass at level ≥ 6 before promotion to \`working\`.

Marking as **draft** so reviewers can flag concerns before I move it out of draft. Happy to transfer the package to YunoHost-Apps and rename if accepted.