### PR TITLE
enh(schemas): allow license.url in manifest

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -106,6 +106,12 @@
             "properties": {
                 "license": {
                     "type": "string"
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "format": "uri"
+                        }
+                    }
                 },
                 "website": {
                     "type": "string",


### PR DESCRIPTION
Related to https://github.com/YunoHost/issues/issues/2348
Requirement for https://github.com/YunoHost/appstore/pull/29 and https://github.com/YunoHost/yunohost-admin/pull/677