### PR TITLE
add(antifeatures): dynamicqrcode

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1228,6 +1228,7 @@ url = "https://github.com/YunoHost-Apps/duniter_ynh"
 
 [dynamicqrcode]
 added_date = 1721508308 # 2024/07/20
+antifeatures = [ "deprecated-software", "non-free-network" ]
 branch = "master"
 category = "small_utilities"
 level = 8


### PR DESCRIPTION
[Upstream repo](https://github.com/giandonatoinverso/PHP-Dynamic-Qr-code) has been deprecated on 2025-09-02, and uses an [external API](https://goqr.me/api/doc/) that does not seem to run on FOSS software.

`non-free-network` might be removed if https://github.com/YunoHost-Apps/dynamicqrcode_ynh/issues/28 is resolved.

