### PR TITLE
Add worflow for automatically optimizing logos

### DIFF
--- a/.github/workflows/optimize_logos.yml
+++ b/.github/workflows/optimize_logos.yml
@@ -1,0 +1,43 @@
+name: Optimize app logos
+
+on:
+  push:
+    branches:
+      - main
+      - pngtest
+    paths:
+      - "logos/**.png"
+
+jobs:
+  optipng:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get added PNG files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: "logos/**.png"
+
+      - name: Install optipng
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: sudo apt-get install -y optipng
+
+      - name: Run optipng on added/modified PNGs
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "Optimizing $file"
+            optipng "$file"
+          done
+
+      - name: Commit optimized files
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: optimize PNG logos with optipng"
+          file_pattern: "logos/**.png"

--- a/.github/workflows/optimize_logos.yml
+++ b/.github/workflows/optimize_logos.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get added PNG files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: "logos/**.png"
 
@@ -36,7 +36,7 @@ jobs:
           done
 
       - name: Commit optimized files
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: optimize PNG logos with optipng"
           file_pattern: "logos/**.png"

--- a/.github/workflows/optimize_logos.yml
+++ b/.github/workflows/optimize_logos.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - pngtest
     paths:
       - "logos/**.png"
 


### PR DESCRIPTION
This workflow will automatically run whenever a new logo is added on `main` branch (just as we run TOML formatters), pushing the added PNG files through `optipng` to optimize the size.

Sample run here: https://github.com/orhtej2/apps/actions/runs/25316464854, resulting commit: https://github.com/orhtej2/apps/commit/232cb15d40893f937f3b21ccd433600a95105653

Disclaimer: **Core of this workflow was generated by Claude Sonnet**