### PR TITLE
fix(schemas): move to license_url

### DIFF
--- a/schemas/manifest.v2.schema.json
+++ b/schemas/manifest.v2.schema.json
@@ -105,13 +105,11 @@
             "additionalProperties": false,
             "properties": {
                 "license": {
+                    "type": "string"
+                },
+                "license_url": {
                     "type": "string",
-                    "properties": {
-                        "url": {
-                            "type": "string",
-                            "format": "uri"
-                        }
-                    }
+                    "format": "uri-reference"
                 },
                 "website": {
                     "type": "string",


### PR DESCRIPTION
Related to https://github.com/YunoHost/issues/issues/2348

It turns out I was introducing invalid TOML with `license` and `license.url` in #3466 and #3473. Let's go simpler.