### PR TITLE
Add mtg-multi to the catalog

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -3554,6 +3554,12 @@ state = "working"
 subtags = [ "proxy" ]
 url = "https://github.com/YunoHost-Apps/mtg_ynh"
 
+[mtg-multi]
+category = "small_utilities"
+state = "working"
+subtags = [ "proxy" ]
+url = "https://github.com/YunoHost-Apps/mtg-multi_ynh"
+
 [mumbleserver]
 added_date = 1674232499 # 2023/01/20
 branch = "master"


### PR DESCRIPTION
This package differs from mtg by support of users. 
each user in yunohost now can see his own key to connect to mtproxy