### PR TITLE
Revive agendav from graveyard

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -111,7 +111,6 @@ state = "working"
 url = "https://github.com/YunoHost-Apps/adventurelog_ynh"
 
 [agendav]
-added_date = 1674232499 # 2023/01/20
 category = "synchronization"
 potential_alternative_to = [ "Google Agenda", "Microsoft Outlook" ]
 subtags = [ "calendar" ]

--- a/apps.toml
+++ b/apps.toml
@@ -111,8 +111,10 @@ state = "working"
 url = "https://github.com/YunoHost-Apps/adventurelog_ynh"
 
 [agendav]
+branch= "main"
 category = "synchronization"
 potential_alternative_to = [ "Google Agenda", "Microsoft Outlook" ]
+state = "working"
 subtags = [ "calendar" ]
 url = "https://github.com/YunoHost-Apps/agendav_ynh"
 

--- a/apps.toml
+++ b/apps.toml
@@ -110,6 +110,13 @@ level = 8
 state = "working"
 url = "https://github.com/YunoHost-Apps/adventurelog_ynh"
 
+[agendav]
+added_date = 1674232499 # 2023/01/20
+category = "synchronization"
+potential_alternative_to = [ "Google Agenda", "Microsoft Outlook" ]
+subtags = [ "calendar" ]
+url = "https://github.com/YunoHost-Apps/agendav_ynh"
+
 [agewasm]
 added_date = 1734129289 # 2024/12/13
 branch = "master"

--- a/graveyard.toml
+++ b/graveyard.toml
@@ -16,16 +16,6 @@ deprecated_date = 1729517763 # 2024/10/21
 killed_date = 1756301846 # 2025/08/27
 url = "https://github.com/YunoHost-Apps/aeneria_ynh"
 
-[agendav]
-added_date = 1674232499 # 2023/01/20
-antifeatures = [ "deprecated-software" ]
-category = "synchronization"
-deprecated_date = 1717071136 # 2024/05/30
-killed_date = 1756379646 # 2025/08/28
-potential_alternative_to = [ "Google Agenda", "Microsoft Outlook" ]
-subtags = [ "calendar" ]
-url = "https://github.com/YunoHost-Apps/agendav_ynh"
-
 [akkoma]
 added_date = 1674232499 # 2023/01/20
 category = "social_media"


### PR DESCRIPTION
agendav upstream has released a version 3.3.1 with an upgrade to php 8.5.   
agendav_ynh is ready to release a version using this 3.3.1 version