### PR TITLE
Mark PeachHub as deprecated

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -4178,6 +4178,7 @@ url = "https://github.com/YunoHost-Apps/paymenter_ynh"
 
 [peachpub]
 added_date = 1674232499 # 2023/01/20
+antifeatures = [ "deprecated-software" ]
 branch = "master"
 category = "communication"
 level = 0


### PR DESCRIPTION
Package is broken, upstream received last commit 4 years ago. This is a preparatory step prior to moving the app to the graveyard.